### PR TITLE
#37 Analytics service API: progress, volume, adherence, summary

### DIFF
--- a/services/analytics/app/config.py
+++ b/services/analytics/app/config.py
@@ -1,4 +1,5 @@
 """Analytics service configuration loaded from environment variables."""
+
 from __future__ import annotations
 
 from pydantic_settings import BaseSettings

--- a/services/analytics/app/database.py
+++ b/services/analytics/app/database.py
@@ -1,0 +1,29 @@
+"""Database connection and session management for analytics service."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+
+engine = create_async_engine(
+    settings.database_url,
+    echo=settings.app_debug,
+    pool_size=5,
+    max_overflow=10,
+)
+
+async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+async def get_db() -> AsyncSession:
+    """Yield a database session for FastAPI dependency injection.
+
+    Yields:
+        AsyncSession that auto-closes after use.
+    """
+    async with async_session() as session:
+        try:
+            yield session
+        finally:
+            await session.close()

--- a/services/analytics/app/dependencies.py
+++ b/services/analytics/app/dependencies.py
@@ -1,0 +1,62 @@
+"""FastAPI dependencies for analytics: JWT verification, current user extraction."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+
+from app.config import settings
+
+security_scheme = HTTPBearer()
+
+
+def decode_access_token(token: str) -> dict | None:
+    """Decode and validate a JWT access token using shared secret.
+
+    Args:
+        token: The JWT string to decode.
+
+    Returns:
+        Token payload dict or None if invalid/expired.
+    """
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+        if payload.get("type") != "access":
+            return None
+        return payload
+    except JWTError:
+        return None
+
+
+async def get_current_user_id(
+    credentials: HTTPAuthorizationCredentials = Depends(security_scheme),
+) -> uuid.UUID:
+    """Extract the current user ID from JWT token.
+
+    Args:
+        credentials: Bearer token from Authorization header.
+
+    Returns:
+        User UUID from the JWT payload.
+
+    Raises:
+        HTTPException: 401 if token is invalid or user_id cannot be parsed.
+    """
+    payload = decode_access_token(credentials.credentials)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        return uuid.UUID(payload["sub"])
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+        ) from exc

--- a/services/analytics/app/main.py
+++ b/services/analytics/app/main.py
@@ -1,10 +1,12 @@
 """Analytics service — Main application entry point."""
+
 from __future__ import annotations
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.router import router as analytics_router
 
 app = FastAPI(
     title="FitnessAI Analytics Service",
@@ -13,6 +15,9 @@ app = FastAPI(
     docs_url="/analytics/docs",
     openapi_url="/analytics/openapi.json",
 )
+
+# Register router
+app.include_router(analytics_router)
 
 # CORS middleware
 origins = [o.strip() for o in settings.cors_origins.split(",")]

--- a/services/analytics/app/models.py
+++ b/services/analytics/app/models.py
@@ -1,0 +1,53 @@
+"""SQLAlchemy ORM models for analytics service — read-only views of workouts data.
+
+The analytics service has cross-schema read access to workouts.* tables.
+These models mirror the workouts schema for query purposes only.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for analytics read-only models."""
+
+    pass
+
+
+class WorkoutSession(Base):
+    """Read-only mirror of workouts.workout_sessions for analytics queries."""
+
+    __tablename__ = "workout_sessions"
+    __table_args__ = {"schema": "workouts"}
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    plan_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    day_name: Mapped[str | None] = mapped_column(String(100))
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    duration_seconds: Mapped[int | None] = mapped_column(Integer)
+    exercises: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text)
+    client_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
+class WorkoutPlan(Base):
+    """Read-only mirror of workouts.workout_plans for adherence calculations."""
+
+    __tablename__ = "workout_plans"
+    __table_args__ = {"schema": "workouts"}
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    days: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))

--- a/services/analytics/app/router.py
+++ b/services/analytics/app/router.py
@@ -1,0 +1,128 @@
+"""Analytics API router: progress, volume, adherence, summary."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.dependencies import get_current_user_id
+from app.schemas import (
+    AdherenceResponse,
+    ProgressDataPoint,
+    ProgressResponse,
+    SummaryResponse,
+    VolumeDataPoint,
+    VolumeResponse,
+)
+from app.service import AnalyticsService
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+@router.get("/progress", response_model=ProgressResponse)
+async def get_progress(
+    exercise_name: str = Query(..., min_length=1),
+    from_date: datetime | None = Query(None, alias="from"),
+    to_date: datetime | None = Query(None, alias="to"),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> ProgressResponse:
+    """Get weight progression for a specific exercise over time.
+
+    Args:
+        exercise_name: Name of the exercise to track.
+        from_date: Optional start date filter.
+        to_date: Optional end date filter.
+        user_id: Authenticated user UUID from JWT.
+        db: Database session.
+
+    Returns:
+        Progress data points for the exercise.
+    """
+    service = AnalyticsService(db)
+    data_points = await service.get_progress(user_id, exercise_name, from_date, to_date)
+    return ProgressResponse(
+        exercise_id=None,
+        exercise_name=exercise_name,
+        data_points=[ProgressDataPoint(**dp) for dp in data_points],
+    )
+
+
+@router.get("/volume", response_model=VolumeResponse)
+async def get_volume(
+    from_date: datetime | None = Query(None, alias="from"),
+    to_date: datetime | None = Query(None, alias="to"),
+    group_by: str = Query("week", pattern="^(week|month)$"),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> VolumeResponse:
+    """Get training volume grouped by week or month.
+
+    Args:
+        from_date: Optional start date filter.
+        to_date: Optional end date filter.
+        group_by: Grouping period ('week' or 'month').
+        user_id: Authenticated user UUID from JWT.
+        db: Database session.
+
+    Returns:
+        Volume data points grouped by period.
+    """
+    service = AnalyticsService(db)
+    data_points = await service.get_volume(user_id, from_date, to_date, group_by)
+    return VolumeResponse(
+        data_points=[VolumeDataPoint(**dp) for dp in data_points],
+        group_by=group_by,
+    )
+
+
+@router.get("/adherence", response_model=AdherenceResponse)
+async def get_adherence(
+    from_date: datetime = Query(
+        default_factory=lambda: datetime.now(UTC) - timedelta(days=30),
+        alias="from",
+    ),
+    to_date: datetime = Query(
+        default_factory=lambda: datetime.now(UTC),
+        alias="to",
+    ),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> AdherenceResponse:
+    """Get workout plan adherence rate for a date range.
+
+    Args:
+        from_date: Start of date range (default: 30 days ago).
+        to_date: End of date range (default: now).
+        user_id: Authenticated user UUID from JWT.
+        db: Database session.
+
+    Returns:
+        Adherence statistics including planned vs completed.
+    """
+    service = AnalyticsService(db)
+    data = await service.get_adherence(user_id, from_date, to_date)
+    return AdherenceResponse(**data)
+
+
+@router.get("/summary", response_model=SummaryResponse)
+async def get_summary(
+    user_id: uuid.UUID = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> SummaryResponse:
+    """Get overall training summary for the authenticated user.
+
+    Args:
+        user_id: Authenticated user UUID from JWT.
+        db: Database session.
+
+    Returns:
+        Summary with totals, streaks, and favorites.
+    """
+    service = AnalyticsService(db)
+    data = await service.get_summary(user_id)
+    return SummaryResponse(**data)

--- a/services/analytics/app/schemas.py
+++ b/services/analytics/app/schemas.py
@@ -1,0 +1,66 @@
+"""Pydantic v2 schemas for analytics service responses."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ProgressDataPoint(BaseModel):
+    """A single data point for exercise weight progression."""
+
+    date: datetime
+    max_weight_kg: float
+    total_volume_kg: float
+    total_sets: int
+    total_reps: int
+
+
+class ProgressResponse(BaseModel):
+    """Response for exercise progress over time."""
+
+    exercise_id: uuid.UUID | None
+    exercise_name: str
+    data_points: list[ProgressDataPoint]
+
+
+class VolumeDataPoint(BaseModel):
+    """A single data point for volume analytics."""
+
+    period: str
+    total_volume_kg: float
+    total_sets: int
+    total_reps: int
+    session_count: int
+
+
+class VolumeResponse(BaseModel):
+    """Response for training volume over time."""
+
+    data_points: list[VolumeDataPoint]
+    group_by: str
+
+
+class AdherenceResponse(BaseModel):
+    """Response for workout plan adherence."""
+
+    planned_days: int
+    completed_sessions: int
+    adherence_rate: float
+    from_date: datetime
+    to_date: datetime
+
+
+class SummaryResponse(BaseModel):
+    """Response for overall training summary."""
+
+    total_sessions: int
+    total_duration_minutes: int
+    total_volume_kg: float
+    current_streak: int
+    longest_streak: int
+    favorite_exercise: str | None
+    sessions_this_week: int
+    sessions_this_month: int

--- a/services/analytics/app/service.py
+++ b/services/analytics/app/service.py
@@ -1,0 +1,272 @@
+"""Analytics business logic: progress, volume, adherence, summary."""
+
+from __future__ import annotations
+
+import uuid
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import WorkoutPlan, WorkoutSession
+
+
+class AnalyticsService:
+    """Computes analytics by reading workout sessions and plans."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def get_progress(
+        self,
+        user_id: uuid.UUID,
+        exercise_name: str,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> list[dict]:
+        """Get weight progression for a specific exercise.
+
+        Scans JSONB exercises field in all sessions and extracts data
+        for the given exercise name.
+
+        Args:
+            user_id: Owner user UUID.
+            exercise_name: Exercise name to track.
+            from_date: Optional start date.
+            to_date: Optional end date.
+
+        Returns:
+            List of data point dicts with date and aggregated metrics.
+        """
+        query = select(WorkoutSession).where(WorkoutSession.user_id == user_id)
+        if from_date:
+            query = query.where(WorkoutSession.started_at >= from_date)
+        if to_date:
+            query = query.where(WorkoutSession.started_at <= to_date)
+        query = query.order_by(WorkoutSession.started_at)
+
+        result = await self.db.execute(query)
+        sessions = result.scalars().all()
+
+        data_points = []
+        for session in sessions:
+            exercises = session.exercises if isinstance(session.exercises, list) else []
+            for ex in exercises:
+                ex_name = ex.get("exercise_name", "")
+                if ex_name.lower() == exercise_name.lower():
+                    sets = ex.get("sets", [])
+                    if not sets:
+                        continue
+                    max_weight = max((s.get("weight_kg", 0) or 0 for s in sets), default=0)
+                    total_volume = sum(
+                        (s.get("weight_kg", 0) or 0) * (s.get("reps", 0) or 0) for s in sets
+                    )
+                    total_sets = len(sets)
+                    total_reps = sum(s.get("reps", 0) or 0 for s in sets)
+
+                    data_points.append(
+                        {
+                            "date": session.started_at,
+                            "max_weight_kg": max_weight,
+                            "total_volume_kg": total_volume,
+                            "total_sets": total_sets,
+                            "total_reps": total_reps,
+                        }
+                    )
+        return data_points
+
+    async def get_volume(
+        self,
+        user_id: uuid.UUID,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+        group_by: str = "week",
+    ) -> list[dict]:
+        """Get training volume grouped by time period.
+
+        Args:
+            user_id: Owner user UUID.
+            from_date: Optional start date.
+            to_date: Optional end date.
+            group_by: Grouping period ('week' or 'month').
+
+        Returns:
+            List of volume data point dicts grouped by period.
+        """
+        query = select(WorkoutSession).where(WorkoutSession.user_id == user_id)
+        if from_date:
+            query = query.where(WorkoutSession.started_at >= from_date)
+        if to_date:
+            query = query.where(WorkoutSession.started_at <= to_date)
+        query = query.order_by(WorkoutSession.started_at)
+
+        result = await self.db.execute(query)
+        sessions = result.scalars().all()
+
+        period_data: dict[str, dict] = {}
+        for session in sessions:
+            dt = session.started_at
+            if group_by == "month":
+                period_key = dt.strftime("%Y-%m")
+            else:
+                # ISO week
+                period_key = f"{dt.isocalendar()[0]}-W{dt.isocalendar()[1]:02d}"
+
+            if period_key not in period_data:
+                period_data[period_key] = {
+                    "period": period_key,
+                    "total_volume_kg": 0.0,
+                    "total_sets": 0,
+                    "total_reps": 0,
+                    "session_count": 0,
+                }
+
+            period_data[period_key]["session_count"] += 1
+            exercises = session.exercises if isinstance(session.exercises, list) else []
+            for ex in exercises:
+                for s in ex.get("sets", []):
+                    weight = s.get("weight_kg", 0) or 0
+                    reps = s.get("reps", 0) or 0
+                    period_data[period_key]["total_volume_kg"] += weight * reps
+                    period_data[period_key]["total_sets"] += 1
+                    period_data[period_key]["total_reps"] += reps
+
+        return list(period_data.values())
+
+    async def get_adherence(
+        self,
+        user_id: uuid.UUID,
+        from_date: datetime,
+        to_date: datetime,
+    ) -> dict:
+        """Calculate workout plan adherence rate.
+
+        Compares actual sessions to planned days in active plans.
+
+        Args:
+            user_id: Owner user UUID.
+            from_date: Start date for calculation.
+            to_date: End date for calculation.
+
+        Returns:
+            Dict with planned_days, completed_sessions, adherence_rate.
+        """
+        # Count active plan days
+        plans_result = await self.db.execute(
+            select(WorkoutPlan).where(
+                WorkoutPlan.user_id == user_id,
+                WorkoutPlan.is_active == True,  # noqa: E712
+            )
+        )
+        plans = plans_result.scalars().all()
+
+        days_per_week = 0
+        for plan in plans:
+            plan_days = plan.days if isinstance(plan.days, list) else []
+            days_per_week += len(plan_days)
+
+        # Calculate expected sessions in date range
+        total_weeks = max(1, (to_date - from_date).days / 7)
+        planned_days = int(days_per_week * total_weeks)
+
+        # Count actual sessions
+        count_result = await self.db.execute(
+            select(func.count())
+            .select_from(WorkoutSession)
+            .where(
+                WorkoutSession.user_id == user_id,
+                WorkoutSession.started_at >= from_date,
+                WorkoutSession.started_at <= to_date,
+            )
+        )
+        completed = count_result.scalar_one()
+
+        adherence = (completed / planned_days) if planned_days > 0 else 0.0
+
+        return {
+            "planned_days": planned_days,
+            "completed_sessions": completed,
+            "adherence_rate": min(1.0, round(adherence, 2)),
+            "from_date": from_date,
+            "to_date": to_date,
+        }
+
+    async def get_summary(self, user_id: uuid.UUID) -> dict:
+        """Get overall training summary statistics.
+
+        Args:
+            user_id: Owner user UUID.
+
+        Returns:
+            Summary dict with aggregated statistics.
+        """
+        result = await self.db.execute(
+            select(WorkoutSession)
+            .where(WorkoutSession.user_id == user_id)
+            .order_by(WorkoutSession.started_at.desc())
+        )
+        sessions = list(result.scalars().all())
+
+        total_sessions = len(sessions)
+        total_duration = sum(s.duration_seconds or 0 for s in sessions)
+        total_volume = 0.0
+        exercise_counter: Counter = Counter()
+
+        now = datetime.now(UTC)
+        week_start = now - timedelta(days=now.weekday())
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        sessions_this_week = 0
+        sessions_this_month = 0
+
+        for session in sessions:
+            if session.started_at.replace(tzinfo=None) >= week_start.replace(tzinfo=None):
+                sessions_this_week += 1
+            if session.started_at.replace(tzinfo=None) >= month_start.replace(tzinfo=None):
+                sessions_this_month += 1
+
+            exercises = session.exercises if isinstance(session.exercises, list) else []
+            for ex in exercises:
+                ex_name = ex.get("exercise_name", "Unknown")
+                exercise_counter[ex_name] += 1
+                for s in ex.get("sets", []):
+                    weight = s.get("weight_kg", 0) or 0
+                    reps = s.get("reps", 0) or 0
+                    total_volume += weight * reps
+
+        # Calculate streaks (consecutive days with sessions)
+        current_streak = 0
+        longest_streak = 0
+        if sessions:
+            session_dates = sorted({s.started_at.date() for s in sessions}, reverse=True)
+            streak = 1
+            for i in range(1, len(session_dates)):
+                if (session_dates[i - 1] - session_dates[i]).days == 1:
+                    streak += 1
+                else:
+                    break
+            current_streak = streak
+
+            streak = 1
+            max_streak = 1
+            for i in range(1, len(session_dates)):
+                if (session_dates[i - 1] - session_dates[i]).days == 1:
+                    streak += 1
+                    max_streak = max(max_streak, streak)
+                else:
+                    streak = 1
+            longest_streak = max_streak
+
+        favorite = exercise_counter.most_common(1)
+        favorite_exercise = favorite[0][0] if favorite else None
+
+        return {
+            "total_sessions": total_sessions,
+            "total_duration_minutes": total_duration // 60,
+            "total_volume_kg": round(total_volume, 1),
+            "current_streak": current_streak,
+            "longest_streak": longest_streak,
+            "favorite_exercise": favorite_exercise,
+            "sessions_this_week": sessions_this_week,
+            "sessions_this_month": sessions_this_month,
+        }

--- a/services/analytics/pyproject.toml
+++ b/services/analytics/pyproject.toml
@@ -4,10 +4,11 @@ line-length = 99
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "T20", "SIM", "ERA"]
-ignore = ["S101"]
+ignore = ["S101", "B008", "E712"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101", "S106"]
+"app/config.py" = ["S105"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/services/analytics/tests/conftest.py
+++ b/services/analytics/tests/conftest.py
@@ -1,0 +1,212 @@
+"""Shared test fixtures for analytics service tests."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from jose import jwt
+from sqlalchemy import JSON
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+from app.database import get_db
+from app.main import app
+from app.models import Base, WorkoutPlan, WorkoutSession
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///./test_analytics.db"
+
+
+def create_test_token(user_id: str | None = None) -> str:
+    """Create a valid JWT access token for testing."""
+    if user_id is None:
+        user_id = str(uuid.uuid4())
+    payload = {
+        "sub": user_id,
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+        "iat": datetime.now(UTC),
+        "type": "access",
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+def _make_sqlite_compatible(base):
+    """Patch SQLAlchemy models for SQLite compatibility."""
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    for table in base.metadata.tables.values():
+        table.schema = None
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an event loop for the test session."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def test_user_id() -> str:
+    """Generate a consistent test user UUID."""
+    return "550e8400-e29b-41d4-a716-446655440000"
+
+
+@pytest.fixture
+def auth_headers(test_user_id: str) -> dict:
+    """Create authorization headers with a valid JWT."""
+    token = create_test_token(test_user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture
+async def test_db() -> AsyncGenerator[AsyncSession, None]:
+    """Create a test database with tables."""
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    _make_sqlite_compatible(Base)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_factory() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_db(test_db: AsyncSession, test_user_id: str) -> AsyncSession:
+    """Create a test database with sample workout data for analytics."""
+    user_uuid = uuid.UUID(test_user_id)
+    now = datetime.now(UTC)
+
+    # Create an active plan with 3 days
+    plan = WorkoutPlan(
+        id=uuid.uuid4(),
+        user_id=user_uuid,
+        name="Push Pull Legs",
+        days=[
+            {"name": "Push", "exercises": []},
+            {"name": "Pull", "exercises": []},
+            {"name": "Legs", "exercises": []},
+        ],
+        is_active=True,
+        created_at=now - timedelta(days=30),
+    )
+    test_db.add(plan)
+
+    # Create sessions over the past 2 weeks
+    sessions = [
+        WorkoutSession(
+            id=uuid.uuid4(),
+            user_id=user_uuid,
+            plan_id=plan.id,
+            day_name="Push",
+            started_at=now - timedelta(days=14),
+            completed_at=now - timedelta(days=14) + timedelta(hours=1),
+            duration_seconds=3600,
+            exercises=[
+                {
+                    "exercise_name": "Bench Press",
+                    "sets": [
+                        {"set_number": 1, "weight_kg": 80, "reps": 10},
+                        {"set_number": 2, "weight_kg": 85, "reps": 8},
+                        {"set_number": 3, "weight_kg": 85, "reps": 7},
+                    ],
+                },
+                {
+                    "exercise_name": "Overhead Press",
+                    "sets": [
+                        {"set_number": 1, "weight_kg": 50, "reps": 10},
+                    ],
+                },
+            ],
+            client_id=uuid.uuid4(),
+            created_at=now - timedelta(days=14),
+        ),
+        WorkoutSession(
+            id=uuid.uuid4(),
+            user_id=user_uuid,
+            plan_id=plan.id,
+            day_name="Pull",
+            started_at=now - timedelta(days=13),
+            completed_at=now - timedelta(days=13) + timedelta(hours=1),
+            duration_seconds=3600,
+            exercises=[
+                {
+                    "exercise_name": "Barbell Row",
+                    "sets": [
+                        {"set_number": 1, "weight_kg": 70, "reps": 10},
+                        {"set_number": 2, "weight_kg": 70, "reps": 8},
+                    ],
+                },
+            ],
+            client_id=uuid.uuid4(),
+            created_at=now - timedelta(days=13),
+        ),
+        WorkoutSession(
+            id=uuid.uuid4(),
+            user_id=user_uuid,
+            plan_id=plan.id,
+            day_name="Push",
+            started_at=now - timedelta(days=7),
+            completed_at=now - timedelta(days=7) + timedelta(minutes=45),
+            duration_seconds=2700,
+            exercises=[
+                {
+                    "exercise_name": "Bench Press",
+                    "sets": [
+                        {"set_number": 1, "weight_kg": 85, "reps": 10},
+                        {"set_number": 2, "weight_kg": 90, "reps": 8},
+                        {"set_number": 3, "weight_kg": 90, "reps": 6},
+                    ],
+                },
+            ],
+            client_id=uuid.uuid4(),
+            created_at=now - timedelta(days=7),
+        ),
+    ]
+    test_db.add_all(sessions)
+    await test_db.commit()
+    return test_db
+
+
+@pytest_asyncio.fixture
+async def client(test_db: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    """Create a test HTTP client."""
+
+    async def override_get_db():
+        yield test_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def seeded_client(seeded_db: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    """Create a test HTTP client with seeded workout data."""
+
+    async def override_get_db():
+        yield seeded_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()

--- a/services/analytics/tests/test_analytics.py
+++ b/services/analytics/tests/test_analytics.py
@@ -1,0 +1,166 @@
+"""Integration tests for analytics API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_progress_no_data(client: AsyncClient, auth_headers: dict):
+    """Progress with no sessions should return empty data points."""
+    response = await client.get(
+        "/analytics/progress",
+        params={"exercise_name": "Bench Press"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["exercise_name"] == "Bench Press"
+    assert data["data_points"] == []
+
+
+@pytest.mark.asyncio
+async def test_progress_with_data(seeded_client: AsyncClient, auth_headers: dict):
+    """Progress with seeded sessions should return data points."""
+    response = await seeded_client.get(
+        "/analytics/progress",
+        params={"exercise_name": "Bench Press"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["exercise_name"] == "Bench Press"
+    assert len(data["data_points"]) == 2
+    # Second session should show progression
+    assert data["data_points"][1]["max_weight_kg"] >= data["data_points"][0]["max_weight_kg"]
+
+
+@pytest.mark.asyncio
+async def test_progress_missing_exercise_name(client: AsyncClient, auth_headers: dict):
+    """Progress without exercise_name should return 422."""
+    response = await client.get("/analytics/progress", headers=auth_headers)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_progress_no_auth(client: AsyncClient):
+    """Progress without auth should return 401."""
+    response = await client.get("/analytics/progress", params={"exercise_name": "Bench Press"})
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_volume_no_data(client: AsyncClient, auth_headers: dict):
+    """Volume with no sessions should return empty data points."""
+    response = await client.get("/analytics/volume", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data_points"] == []
+    assert data["group_by"] == "week"
+
+
+@pytest.mark.asyncio
+async def test_volume_with_data(seeded_client: AsyncClient, auth_headers: dict):
+    """Volume with seeded sessions should return grouped data."""
+    response = await seeded_client.get("/analytics/volume", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data_points"]) >= 1
+    for dp in data["data_points"]:
+        assert dp["total_volume_kg"] > 0
+        assert dp["session_count"] > 0
+
+
+@pytest.mark.asyncio
+async def test_volume_group_by_month(seeded_client: AsyncClient, auth_headers: dict):
+    """Volume grouped by month should use YYYY-MM format."""
+    response = await seeded_client.get(
+        "/analytics/volume",
+        params={"group_by": "month"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["group_by"] == "month"
+    for dp in data["data_points"]:
+        assert len(dp["period"]) == 7  # YYYY-MM
+
+
+@pytest.mark.asyncio
+async def test_volume_invalid_group_by(client: AsyncClient, auth_headers: dict):
+    """Volume with invalid group_by should return 422."""
+    response = await client.get(
+        "/analytics/volume",
+        params={"group_by": "day"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_adherence_no_data(client: AsyncClient, auth_headers: dict):
+    """Adherence with no plans/sessions should return 0 rate."""
+    response = await client.get(
+        "/analytics/adherence",
+        params={
+            "from": "2026-03-01T00:00:00Z",
+            "to": "2026-03-31T23:59:59Z",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["planned_days"] == 0
+    assert data["completed_sessions"] == 0
+    assert data["adherence_rate"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_adherence_with_data(seeded_client: AsyncClient, auth_headers: dict):
+    """Adherence with seeded data should calculate rate correctly."""
+    response = await seeded_client.get(
+        "/analytics/adherence",
+        params={
+            "from": "2026-03-01T00:00:00Z",
+            "to": "2026-04-30T23:59:59Z",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["completed_sessions"] == 3
+    assert data["planned_days"] > 0
+    assert 0 <= data["adherence_rate"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_summary_no_data(client: AsyncClient, auth_headers: dict):
+    """Summary with no sessions should return zeros."""
+    response = await client.get("/analytics/summary", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_sessions"] == 0
+    assert data["total_duration_minutes"] == 0
+    assert data["total_volume_kg"] == 0
+    assert data["current_streak"] == 0
+    assert data["favorite_exercise"] is None
+
+
+@pytest.mark.asyncio
+async def test_summary_with_data(seeded_client: AsyncClient, auth_headers: dict):
+    """Summary with seeded data should return correct stats."""
+    response = await seeded_client.get("/analytics/summary", headers=auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_sessions"] == 3
+    assert data["total_duration_minutes"] > 0
+    assert data["total_volume_kg"] > 0
+    assert data["favorite_exercise"] == "Bench Press"
+
+
+@pytest.mark.asyncio
+async def test_summary_no_auth(client: AsyncClient):
+    """Summary without auth should return 401."""
+    response = await client.get("/analytics/summary")
+    assert response.status_code in (401, 403)

--- a/services/analytics/tests/test_health.py
+++ b/services/analytics/tests/test_health.py
@@ -1,0 +1,17 @@
+"""Tests for health check endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_ok(client: AsyncClient):
+    """Health endpoint should return status ok, service name, and version."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["service"] == "analytics"
+    assert "version" in data


### PR DESCRIPTION
## Summary
- Implement complete **analytics service** with 4 endpoints:
  - `GET /analytics/progress` — exercise weight progression over time
  - `GET /analytics/volume` — training volume grouped by week/month
  - `GET /analytics/adherence` — workout plan adherence rate
  - `GET /analytics/summary` — overall stats (totals, streaks, favorites)
- Cross-schema read access to workouts.* tables via read-only models
- JSONB parsing for exercise sets data within sessions

## Test plan
- [x] `pytest services/analytics/tests/ -v` — 14 passed
- [x] `ruff check` and `ruff format` clean
- [ ] CI pipeline runs on PR

Closes #37 Closes #13