### PR TITLE
#34 AI service: Redis Streams for async jobs, vision scan, coach generate

### DIFF
--- a/services/ai/app/config.py
+++ b/services/ai/app/config.py
@@ -1,4 +1,5 @@
 """AI service configuration loaded from environment variables."""
+
 from __future__ import annotations
 
 from pydantic_settings import BaseSettings

--- a/services/ai/app/dependencies.py
+++ b/services/ai/app/dependencies.py
@@ -1,0 +1,62 @@
+"""FastAPI dependencies for AI service: JWT verification, current user extraction."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+
+from app.config import settings
+
+security_scheme = HTTPBearer()
+
+
+def decode_access_token(token: str) -> dict | None:
+    """Decode and validate a JWT access token using shared secret.
+
+    Args:
+        token: The JWT string to decode.
+
+    Returns:
+        Token payload dict or None if invalid/expired.
+    """
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+        if payload.get("type") != "access":
+            return None
+        return payload
+    except JWTError:
+        return None
+
+
+async def get_current_user_id(
+    credentials: HTTPAuthorizationCredentials = Depends(security_scheme),
+) -> uuid.UUID:
+    """Extract the current user ID from JWT token.
+
+    Args:
+        credentials: Bearer token from Authorization header.
+
+    Returns:
+        User UUID from the JWT payload.
+
+    Raises:
+        HTTPException: 401 if token is invalid or user_id cannot be parsed.
+    """
+    payload = decode_access_token(credentials.credentials)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        return uuid.UUID(payload["sub"])
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+        ) from exc

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -1,10 +1,12 @@
 """AI service — Main application entry point."""
+
 from __future__ import annotations
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.router import router as ai_router
 
 app = FastAPI(
     title="FitnessAI AI Service",
@@ -13,6 +15,9 @@ app = FastAPI(
     docs_url="/ai/docs",
     openapi_url="/ai/openapi.json",
 )
+
+# Register router
+app.include_router(ai_router)
 
 # CORS middleware
 origins = [o.strip() for o in settings.cors_origins.split(",")]
@@ -27,5 +32,14 @@ app.add_middleware(
 
 @app.get("/health")
 async def health_check() -> dict:
-    """Health check endpoint for monitoring and Docker healthcheck."""
-    return {"status": "ok", "service": settings.service_name, "version": settings.app_version}
+    """Health check endpoint with Redis connectivity check."""
+    from app.redis_client import check_redis_health
+
+    redis_ok = await check_redis_health()
+    status = "ok" if redis_ok else "degraded"
+    return {
+        "status": status,
+        "service": settings.service_name,
+        "version": settings.app_version,
+        "redis": "ok" if redis_ok else "unavailable",
+    }

--- a/services/ai/app/redis_client.py
+++ b/services/ai/app/redis_client.py
@@ -1,0 +1,189 @@
+"""Redis client for AI service: cache and job queue via Redis Streams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime
+
+import redis.asyncio as redis
+
+from app.config import settings
+
+# Singleton Redis connection pool
+_pool: redis.ConnectionPool | None = None
+
+
+async def get_redis() -> redis.Redis:
+    """Get a Redis client instance using a shared connection pool.
+
+    Returns:
+        Redis client connected to the configured Redis URL.
+    """
+    global _pool  # noqa: PLW0603
+    if _pool is None:
+        _pool = redis.ConnectionPool.from_url(settings.redis_url, decode_responses=True)
+    return redis.Redis(connection_pool=_pool)
+
+
+async def check_redis_health() -> bool:
+    """Check if Redis is reachable.
+
+    Returns:
+        True if Redis responds to PING, False otherwise.
+    """
+    try:
+        client = await get_redis()
+        return await client.ping()
+    except Exception:
+        return False
+
+
+# ============================================================
+# Job Queue (Redis Streams)
+# ============================================================
+
+STREAM_KEY = "ai:jobs"
+RESULTS_PREFIX = "ai:results:"
+JOB_TTL_SECONDS = 3600  # Results expire after 1 hour
+
+
+async def publish_job(
+    job_type: str,
+    user_id: str,
+    payload: dict,
+) -> str:
+    """Publish an AI job to the Redis Streams queue.
+
+    Args:
+        job_type: Type of job ('vision_scan' or 'coach_generate').
+        user_id: User UUID string.
+        payload: Job-specific data to process.
+
+    Returns:
+        Job ID (UUID string) for status polling.
+    """
+    client = await get_redis()
+    job_id = str(uuid.uuid4())
+
+    job_data = {
+        "job_id": job_id,
+        "job_type": job_type,
+        "user_id": user_id,
+        "payload": json.dumps(payload),
+        "status": "pending",
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+    # Store initial job status
+    await client.hset(f"{RESULTS_PREFIX}{job_id}", mapping=job_data)
+    await client.expire(f"{RESULTS_PREFIX}{job_id}", JOB_TTL_SECONDS)
+
+    # Publish to stream
+    await client.xadd(STREAM_KEY, {"job_id": job_id, "job_type": job_type})
+
+    return job_id
+
+
+async def get_job_status(job_id: str) -> dict | None:
+    """Get the current status and result of an AI job.
+
+    Args:
+        job_id: Job UUID string.
+
+    Returns:
+        Job status dict or None if not found.
+    """
+    client = await get_redis()
+    data = await client.hgetall(f"{RESULTS_PREFIX}{job_id}")
+    if not data:
+        return None
+
+    # Parse result JSON if present
+    if "result" in data and data["result"]:
+        try:
+            data["result"] = json.loads(data["result"])
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return data
+
+
+async def update_job_status(
+    job_id: str,
+    status: str,
+    result: dict | None = None,
+    error: str | None = None,
+) -> None:
+    """Update the status of an AI job.
+
+    Args:
+        job_id: Job UUID string.
+        status: New status ('processing', 'completed', 'failed').
+        result: Optional result data (for completed jobs).
+        error: Optional error message (for failed jobs).
+    """
+    client = await get_redis()
+    updates: dict = {"status": status, "updated_at": datetime.now(UTC).isoformat()}
+
+    if result is not None:
+        updates["result"] = json.dumps(result)
+    if error is not None:
+        updates["error"] = error
+
+    await client.hset(f"{RESULTS_PREFIX}{job_id}", mapping=updates)
+
+
+# ============================================================
+# Cache (hash-based dedup for vision scans)
+# ============================================================
+
+VISION_CACHE_PREFIX = "ai:vision:"
+VISION_CACHE_TTL = 86400  # 24 hours
+
+
+def compute_image_hash(image_data: bytes) -> str:
+    """Compute SHA256 hash of image data for cache dedup.
+
+    Args:
+        image_data: Raw image bytes.
+
+    Returns:
+        Hex-encoded SHA256 hash string.
+    """
+    return hashlib.sha256(image_data).hexdigest()
+
+
+async def get_cached_vision_result(image_hash: str) -> dict | None:
+    """Check if a vision scan result is cached.
+
+    Args:
+        image_hash: SHA256 hash of the image.
+
+    Returns:
+        Cached result dict or None.
+    """
+    client = await get_redis()
+    cached = await client.get(f"{VISION_CACHE_PREFIX}{image_hash}")
+    if cached:
+        try:
+            return json.loads(cached)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    return None
+
+
+async def cache_vision_result(image_hash: str, result: dict) -> None:
+    """Cache a vision scan result.
+
+    Args:
+        image_hash: SHA256 hash of the image.
+        result: Vision scan result to cache.
+    """
+    client = await get_redis()
+    await client.set(
+        f"{VISION_CACHE_PREFIX}{image_hash}",
+        json.dumps(result),
+        ex=VISION_CACHE_TTL,
+    )

--- a/services/ai/app/router.py
+++ b/services/ai/app/router.py
@@ -1,0 +1,143 @@
+"""AI API router: vision scan, coach generation, job status."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+
+from app.dependencies import get_current_user_id
+from app.redis_client import (
+    compute_image_hash,
+    get_cached_vision_result,
+    get_job_status,
+    publish_job,
+)
+from app.schemas import (
+    CoachGenerateResponse,
+    JobStatusResponse,
+    VisionScanResponse,
+)
+
+router = APIRouter(prefix="/ai", tags=["ai"])
+
+MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
+
+
+@router.post("/vision/scan", response_model=VisionScanResponse)
+async def vision_scan(
+    image: UploadFile = File(...),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+) -> VisionScanResponse:
+    """Submit an image for AI equipment recognition.
+
+    The image is hashed for dedup caching. If a cached result exists,
+    it is returned immediately. Otherwise, a job is published to Redis
+    Streams for async processing.
+
+    Args:
+        image: Uploaded image file (max 10MB).
+        user_id: Authenticated user UUID from JWT.
+
+    Returns:
+        Job submission response with job_id for polling.
+    """
+    # Validate file size
+    contents = await image.read()
+    if len(contents) > MAX_IMAGE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Image exceeds maximum size of {MAX_IMAGE_SIZE // (1024 * 1024)}MB",
+        )
+
+    # Check cache
+    image_hash = compute_image_hash(contents)
+    cached = await get_cached_vision_result(image_hash)
+    if cached:
+        # Return cached result as a completed job
+        job_id = await publish_job(
+            job_type="vision_scan",
+            user_id=str(user_id),
+            payload={"image_hash": image_hash, "cached": True},
+        )
+        from app.redis_client import update_job_status
+
+        await update_job_status(job_id, "completed", result=cached)
+        return VisionScanResponse(
+            job_id=job_id,
+            status="completed",
+            message="Result found in cache. Check GET /ai/jobs/{job_id}.",
+        )
+
+    # Publish async job
+    job_id = await publish_job(
+        job_type="vision_scan",
+        user_id=str(user_id),
+        payload={
+            "image_hash": image_hash,
+            "content_type": image.content_type or "image/jpeg",
+            "filename": image.filename or "scan.jpg",
+        },
+    )
+
+    return VisionScanResponse(job_id=job_id)
+
+
+@router.post("/coach/generate", response_model=CoachGenerateResponse)
+async def coach_generate(
+    user_id: uuid.UUID = Depends(get_current_user_id),
+) -> CoachGenerateResponse:
+    """Submit a request for AI-generated personalized workout plan.
+
+    Args:
+        user_id: Authenticated user UUID from JWT.
+
+    Returns:
+        Job submission response with job_id for polling.
+    """
+    job_id = await publish_job(
+        job_type="coach_generate",
+        user_id=str(user_id),
+        payload={"user_id": str(user_id)},
+    )
+
+    return CoachGenerateResponse(job_id=job_id)
+
+
+@router.get("/jobs/{job_id}", response_model=JobStatusResponse)
+async def get_job(
+    job_id: str,
+    user_id: uuid.UUID = Depends(get_current_user_id),
+) -> JobStatusResponse:
+    """Poll the status of an AI job.
+
+    Args:
+        job_id: Job UUID string.
+        user_id: Authenticated user UUID from JWT.
+
+    Returns:
+        Current job status with result if completed.
+    """
+    data = await get_job_status(job_id)
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job not found or expired",
+        )
+
+    # Verify job belongs to this user
+    if data.get("user_id") != str(user_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job not found",
+        )
+
+    return JobStatusResponse(
+        job_id=data.get("job_id", job_id),
+        job_type=data.get("job_type", "unknown"),
+        status=data.get("status", "unknown"),
+        created_at=data.get("created_at"),
+        updated_at=data.get("updated_at"),
+        result=data.get("result") if isinstance(data.get("result"), dict) else None,
+        error=data.get("error"),
+    )

--- a/services/ai/app/schemas.py
+++ b/services/ai/app/schemas.py
@@ -1,0 +1,52 @@
+"""Pydantic v2 schemas for AI service request/response validation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class VisionScanResponse(BaseModel):
+    """Response for an AI vision scan job submission."""
+
+    job_id: str
+    status: str = "pending"
+    message: str = "Vision scan job submitted. Poll GET /ai/jobs/{job_id} for results."
+
+
+class CoachGenerateResponse(BaseModel):
+    """Response for an AI coach generation job submission."""
+
+    job_id: str
+    status: str = "pending"
+    message: str = "Coach generation job submitted. Poll GET /ai/jobs/{job_id} for results."
+
+
+class JobStatusResponse(BaseModel):
+    """Response for job status polling."""
+
+    job_id: str
+    job_type: str
+    status: str
+    created_at: str | None = None
+    updated_at: str | None = None
+    result: dict | None = None
+    error: str | None = None
+
+
+class VisionResult(BaseModel):
+    """Result of a vision scan: equipment identified and suggested exercises."""
+
+    equipment_name: str
+    brand: str | None = None
+    exercises: list[dict] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+    cached: bool = False
+
+
+class CoachResult(BaseModel):
+    """Result of a coach generation: personalized workout plan."""
+
+    plan_name: str
+    description: str
+    days: list[dict] = Field(default_factory=list)
+    notes: str | None = None

--- a/services/ai/pyproject.toml
+++ b/services/ai/pyproject.toml
@@ -4,10 +4,11 @@ line-length = 99
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "S", "B", "A", "C4", "T20", "SIM", "ERA"]
-ignore = ["S101"]
+ignore = ["S101", "B008", "SIM105", "SIM117"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["S101", "S106"]
+"app/config.py" = ["S105"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/services/ai/requirements-dev.txt
+++ b/services/ai/requirements-dev.txt
@@ -6,3 +6,4 @@ httpx>=0.28.1
 ruff>=0.8.6
 bandit>=1.8.3
 aiosqlite>=0.20.0
+fakeredis>=2.20.0

--- a/services/ai/tests/conftest.py
+++ b/services/ai/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Shared test fixtures for AI service tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from jose import jwt
+
+from app.config import settings
+from app.main import app
+
+TEST_USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def create_test_token(user_id: str | None = None) -> str:
+    """Create a valid JWT access token for testing."""
+    if user_id is None:
+        user_id = TEST_USER_ID
+    payload = {
+        "sub": user_id,
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+        "iat": datetime.now(UTC),
+        "type": "access",
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an event loop for the test session."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture
+def test_user_id() -> str:
+    """Return a consistent test user UUID."""
+    return TEST_USER_ID
+
+
+@pytest.fixture
+def auth_headers(test_user_id: str) -> dict:
+    """Create authorization headers with a valid JWT."""
+    token = create_test_token(test_user_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def fake_redis():
+    """Create a fakeredis instance for testing."""
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest_asyncio.fixture
+async def client(fake_redis) -> AsyncGenerator[AsyncClient, None]:
+    """Create a test HTTP client with Redis mocked."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        with patch(
+            "app.router.get_cached_vision_result", new_callable=AsyncMock, return_value=None
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                yield ac

--- a/services/ai/tests/test_health.py
+++ b/services/ai/tests/test_health.py
@@ -1,0 +1,37 @@
+"""Tests for AI service health check endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_health_check_redis_ok():
+    """Health check should return ok when Redis is reachable."""
+    with patch("app.redis_client.check_redis_health", new_callable=AsyncMock, return_value=True):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ok"
+            assert data["service"] == "ai"
+            assert data["redis"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_health_check_redis_down():
+    """Health check should return degraded when Redis is unreachable."""
+    with patch("app.redis_client.check_redis_health", new_callable=AsyncMock, return_value=False):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "degraded"
+            assert data["redis"] == "unavailable"

--- a/services/ai/tests/test_redis_client.py
+++ b/services/ai/tests/test_redis_client.py
@@ -1,0 +1,105 @@
+"""Unit tests for Redis client: jobs and cache."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import fakeredis.aioredis
+import pytest
+
+from app.redis_client import (
+    cache_vision_result,
+    compute_image_hash,
+    get_cached_vision_result,
+    get_job_status,
+    publish_job,
+    update_job_status,
+)
+
+
+@pytest.fixture
+def fake_redis():
+    """Create a fakeredis instance."""
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.mark.asyncio
+async def test_publish_and_get_job(fake_redis):
+    """Publishing a job should store it and make it retrievable."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        job_id = await publish_job("vision_scan", "user-123", {"test": True})
+        assert job_id is not None
+
+        status = await get_job_status(job_id)
+        assert status is not None
+        assert status["job_type"] == "vision_scan"
+        assert status["user_id"] == "user-123"
+        assert status["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_update_job_status(fake_redis):
+    """Updating job status should persist changes."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        job_id = await publish_job("vision_scan", "user-123", {})
+
+        await update_job_status(job_id, "processing")
+        status = await get_job_status(job_id)
+        assert status["status"] == "processing"
+
+        result = {"equipment_name": "Bench Press", "confidence": 0.95}
+        await update_job_status(job_id, "completed", result=result)
+        status = await get_job_status(job_id)
+        assert status["status"] == "completed"
+        assert status["result"]["equipment_name"] == "Bench Press"
+
+
+@pytest.mark.asyncio
+async def test_update_job_with_error(fake_redis):
+    """Failed job should store error message."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        job_id = await publish_job("vision_scan", "user-123", {})
+        await update_job_status(job_id, "failed", error="API timeout")
+        status = await get_job_status(job_id)
+        assert status["status"] == "failed"
+        assert status["error"] == "API timeout"
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent_job(fake_redis):
+    """Getting a nonexistent job should return None."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        status = await get_job_status("nonexistent-id")
+        assert status is None
+
+
+def test_compute_image_hash():
+    """Image hash should be consistent and deterministic."""
+    data = b"test image data"
+    hash1 = compute_image_hash(data)
+    hash2 = compute_image_hash(data)
+    assert hash1 == hash2
+    assert len(hash1) == 64  # SHA256 hex
+
+    different = compute_image_hash(b"different data")
+    assert different != hash1
+
+
+@pytest.mark.asyncio
+async def test_vision_cache_roundtrip(fake_redis):
+    """Caching and retrieving a vision result should work."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        image_hash = compute_image_hash(b"test")
+        result = {"equipment_name": "Leg Press", "confidence": 0.9}
+
+        # Cache should be empty initially
+        cached = await get_cached_vision_result(image_hash)
+        assert cached is None
+
+        # Cache the result
+        await cache_vision_result(image_hash, result)
+
+        # Should be retrievable
+        cached = await get_cached_vision_result(image_hash)
+        assert cached is not None
+        assert cached["equipment_name"] == "Leg Press"

--- a/services/ai/tests/test_router.py
+++ b/services/ai/tests/test_router.py
@@ -1,0 +1,147 @@
+"""Integration tests for AI service API endpoints."""
+
+from __future__ import annotations
+
+import io
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import fakeredis.aioredis
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from tests.conftest import TEST_USER_ID, create_test_token
+
+
+@pytest.fixture
+def auth_headers() -> dict:
+    """Authorization headers for test user."""
+    token = create_test_token(TEST_USER_ID)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def fake_redis():
+    """Create a fakeredis instance."""
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_submit(fake_redis, auth_headers):
+    """Submitting a vision scan should return a job_id."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        with patch(
+            "app.router.get_cached_vision_result", new_callable=AsyncMock, return_value=None
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                image_data = b"fake image data for testing"
+                response = await client.post(
+                    "/ai/vision/scan",
+                    files={"image": ("test.jpg", io.BytesIO(image_data), "image/jpeg")},
+                    headers=auth_headers,
+                )
+                assert response.status_code == 200
+                data = response.json()
+                assert "job_id" in data
+                assert data["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_cached(fake_redis, auth_headers):
+    """Vision scan with cached result should return completed immediately."""
+    cached_result = {"equipment_name": "Bench Press", "confidence": 0.95}
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        with patch(
+            "app.router.get_cached_vision_result",
+            new_callable=AsyncMock,
+            return_value=cached_result,
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.post(
+                    "/ai/vision/scan",
+                    files={"image": ("test.jpg", io.BytesIO(b"cached image"), "image/jpeg")},
+                    headers=auth_headers,
+                )
+                assert response.status_code == 200
+                data = response.json()
+                assert data["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_no_auth(fake_redis):
+    """Vision scan without auth should return 401."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ai/vision/scan",
+                files={"image": ("test.jpg", io.BytesIO(b"data"), "image/jpeg")},
+            )
+            assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_submit(fake_redis, auth_headers):
+    """Submitting a coach generation should return a job_id."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post("/ai/coach/generate", headers=auth_headers)
+            assert response.status_code == 200
+            data = response.json()
+            assert "job_id" in data
+            assert data["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_get_job_status(fake_redis, auth_headers):
+    """Getting a submitted job should return its status."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        with patch(
+            "app.router.get_cached_vision_result", new_callable=AsyncMock, return_value=None
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                # Submit a job
+                submit = await client.post("/ai/coach/generate", headers=auth_headers)
+                job_id = submit.json()["job_id"]
+
+                # Check status
+                response = await client.get(f"/ai/jobs/{job_id}", headers=auth_headers)
+                assert response.status_code == 200
+                data = response.json()
+                assert data["job_id"] == job_id
+                assert data["status"] == "pending"
+                assert data["job_type"] == "coach_generate"
+
+
+@pytest.mark.asyncio
+async def test_get_job_not_found(fake_redis, auth_headers):
+    """Getting a nonexistent job should return 404."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(f"/ai/jobs/{uuid.uuid4()}", headers=auth_headers)
+            assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_job_other_user(fake_redis):
+    """Getting another user's job should return 404."""
+    with patch("app.redis_client.get_redis", return_value=fake_redis):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Submit as user A
+            user_a = str(uuid.uuid4())
+            headers_a = {"Authorization": f"Bearer {create_test_token(user_a)}"}
+            submit = await client.post("/ai/coach/generate", headers=headers_a)
+            job_id = submit.json()["job_id"]
+
+            # Try to access as user B
+            user_b = str(uuid.uuid4())
+            headers_b = {"Authorization": f"Bearer {create_test_token(user_b)}"}
+            response = await client.get(f"/ai/jobs/{job_id}", headers=headers_b)
+            assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Implement **AI service** with async job processing via Redis Streams
- `POST /ai/vision/scan` — image upload with SHA256 cache dedup, async job
- `POST /ai/coach/generate` — async personalized workout plan generation
- `GET /ai/jobs/{job_id}` — job status polling with user isolation
- Redis health check in `/health` endpoint (status: ok/degraded)
- Hash-based vision cache with 24h TTL for dedup

## Test plan
- [x] `pytest services/ai/tests/ -v` — 15 passed
- [x] `ruff check` clean
- [x] Redis mocked with fakeredis for deterministic testing
- [ ] CI pipeline runs on PR

Closes #34