### PR TITLE
[Mobile] Workout tracker screen with set logging

### DIFF
--- a/app/lib/core/services/rest_timer_service.dart
+++ b/app/lib/core/services/rest_timer_service.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Service for the rest timer between sets.
+/// Uses absolute timestamp so the timer continues even when backgrounded.
+class RestTimerService extends ChangeNotifier {
+  Timer? _timer;
+  DateTime? _endTime;
+  int _totalSeconds = 0;
+  bool _isRunning = false;
+
+  int get remainingSeconds {
+    if (_endTime == null) return 0;
+    final remaining = _endTime!.difference(DateTime.now()).inSeconds;
+    return remaining > 0 ? remaining : 0;
+  }
+
+  int get totalSeconds => _totalSeconds;
+  bool get isRunning => _isRunning && remainingSeconds > 0;
+
+  double get progress {
+    if (_totalSeconds <= 0) return 0;
+    return 1.0 - (remainingSeconds / _totalSeconds);
+  }
+
+  String get formattedTime {
+    final sec = remainingSeconds;
+    final min = sec ~/ 60;
+    final s = sec % 60;
+    return '${min.toString().padLeft(2, '0')}:${s.toString().padLeft(2, '0')}';
+  }
+
+  /// Start the timer with the given seconds.
+  void start(int seconds) {
+    stop();
+    _totalSeconds = seconds;
+    _endTime = DateTime.now().add(Duration(seconds: seconds));
+    _isRunning = true;
+    notifyListeners();
+
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (remainingSeconds <= 0) {
+        _isRunning = false;
+        _timer?.cancel();
+        _timer = null;
+      }
+      notifyListeners();
+    });
+  }
+
+  /// Add 30 seconds to the current timer.
+  void addThirtySeconds() {
+    if (_endTime != null) {
+      _endTime = _endTime!.add(const Duration(seconds: 30));
+      _totalSeconds += 30;
+    }
+    if (!_isRunning) {
+      _isRunning = true;
+      _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+        if (remainingSeconds <= 0) {
+          _isRunning = false;
+          _timer?.cancel();
+          _timer = null;
+        }
+        notifyListeners();
+      });
+    }
+    notifyListeners();
+  }
+
+  /// Skip (stop) the timer.
+  void skip() => stop();
+
+  /// Stop and reset the timer.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _endTime = null;
+    _totalSeconds = 0;
+    _isRunning = false;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/app/lib/features/workout/data/workout_repository.dart
+++ b/app/lib/features/workout/data/workout_repository.dart
@@ -1,0 +1,172 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:fitness_ai/core/constants/api_constants.dart';
+import 'package:fitness_ai/core/network/api_client.dart';
+import 'package:fitness_ai/core/network/api_exception.dart';
+import 'package:fitness_ai/core/storage/hive_storage.dart';
+import 'package:fitness_ai/features/workout/domain/exercise.dart';
+import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+
+const _uuid = Uuid();
+
+/// Repository for workout data.
+/// Offline-first: writes to Hive, then syncs to API.
+class WorkoutRepository {
+  WorkoutRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  // ============================================================
+  // Sessions (local-first)
+  // ============================================================
+
+  /// Save a session to local Hive storage.
+  Future<void> saveSessionLocally(WorkoutSession session) async {
+    await HiveStorage.sessions.put(session.id, session.toJson());
+  }
+
+  /// Get a session by ID from local storage.
+  WorkoutSession? getSession(String id) {
+    final data = HiveStorage.sessions.get(id);
+    if (data == null) return null;
+    return WorkoutSession.fromJson(Map<String, dynamic>.from(data));
+  }
+
+  /// Get all local sessions, most recent first.
+  List<WorkoutSession> getAllLocalSessions() {
+    return HiveStorage.sessions.values
+        .map((m) => WorkoutSession.fromJson(Map<String, dynamic>.from(m)))
+        .toList()
+      ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+  }
+
+  /// Get unsynced sessions that need to be sent to the API.
+  List<WorkoutSession> getUnsyncedSessions() {
+    return getAllLocalSessions()
+        .where((s) => s.isCompleted && !s.synced)
+        .toList();
+  }
+
+  /// Generate a new session ID.
+  String generateSessionId() => _uuid.v4();
+
+  /// Sync a completed session to the API.
+  Future<void> syncSession(WorkoutSession session) async {
+    try {
+      await apiClient.post(
+        ApiConstants.workoutSessions,
+        data: {
+          'client_id': session.id,
+          'plan_id': session.planId,
+          'day_name': session.dayName,
+          'started_at': session.startedAt.toIso8601String(),
+          'completed_at': session.completedAt?.toIso8601String(),
+          'duration_seconds': session.durationSeconds,
+          'exercises': session.exercises
+              .where((e) => !e.skipped)
+              .map((e) => e.toApiJson())
+              .toList(),
+          'notes': session.notes.isNotEmpty ? session.notes : null,
+        },
+      );
+      // Mark as synced locally
+      final synced = session.copyWith(synced: true);
+      await saveSessionLocally(synced);
+    } on DioException catch (e) {
+      // If conflict (duplicate), mark as synced
+      if (e.response?.statusCode == 409) {
+        final synced = session.copyWith(synced: true);
+        await saveSessionLocally(synced);
+      } else {
+        throw ApiException.fromDioException(e);
+      }
+    }
+  }
+
+  /// Sync all unsynced sessions.
+  Future<int> syncAllPending() async {
+    final pending = getUnsyncedSessions();
+    int synced = 0;
+    for (final session in pending) {
+      try {
+        await syncSession(session);
+        synced++;
+      } catch (_) {
+        // Continue syncing other sessions
+      }
+    }
+    return synced;
+  }
+
+  // ============================================================
+  // Plans (API-first with local cache)
+  // ============================================================
+
+  /// Fetch workout plans from API and cache locally.
+  Future<List<WorkoutPlan>> fetchPlans() async {
+    try {
+      final response = await apiClient.get(ApiConstants.workoutPlans);
+      final data = response.data as Map<String, dynamic>;
+      final items = (data['items'] as List?) ?? [];
+      final plans = items
+          .map((item) =>
+              WorkoutPlan.fromJson(item as Map<String, dynamic>))
+          .toList();
+
+      // Cache locally
+      for (final plan in plans) {
+        await HiveStorage.plans.put(plan.id, plan.toJson());
+      }
+
+      return plans;
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  /// Get cached plans from Hive (for offline use).
+  List<WorkoutPlan> getCachedPlans() {
+    return HiveStorage.plans.values
+        .map((m) => WorkoutPlan.fromJson(Map<String, dynamic>.from(m)))
+        .toList();
+  }
+
+  // ============================================================
+  // Exercises (API-first with local cache)
+  // ============================================================
+
+  /// Fetch exercises catalog from API and cache locally.
+  Future<List<Exercise>> fetchExercises() async {
+    try {
+      final response = await apiClient.get(ApiConstants.workoutExercises);
+      final items = (response.data as List?) ?? [];
+      final exercises = items
+          .map((item) => Exercise.fromJson(item as Map<String, dynamic>))
+          .toList();
+
+      // Cache locally
+      for (final ex in exercises) {
+        await HiveStorage.exercises.put(ex.id, ex.toJson());
+      }
+
+      return exercises;
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  /// Get cached exercises from Hive (for offline use).
+  List<Exercise> getCachedExercises() {
+    return HiveStorage.exercises.values
+        .map((m) => Exercise.fromJson(Map<String, dynamic>.from(m)))
+        .toList();
+  }
+}
+
+/// Provider for workout repository.
+final workoutRepositoryProvider = Provider<WorkoutRepository>((ref) {
+  return WorkoutRepository(apiClient: ref.watch(apiClientProvider));
+});

--- a/app/lib/features/workout/domain/exercise.dart
+++ b/app/lib/features/workout/domain/exercise.dart
@@ -1,0 +1,50 @@
+/// Exercise reference data from the exercises catalog.
+class Exercise {
+  const Exercise({
+    required this.id,
+    required this.name,
+    this.nameEn,
+    this.muscleGroups,
+    this.equipment,
+    this.exerciseType = 'weighted',
+    this.description,
+    this.descriptionEn,
+    this.isCustom = false,
+  });
+
+  final String id;
+  final String name;
+  final String? nameEn;
+  final List<String>? muscleGroups;
+  final String? equipment;
+  final String exerciseType; // weighted, timed, bodyweight
+  final String? description;
+  final String? descriptionEn;
+  final bool isCustom;
+
+  factory Exercise.fromJson(Map<String, dynamic> json) {
+    return Exercise(
+      id: json['id'].toString(),
+      name: json['name'] as String,
+      nameEn: json['name_en'] as String?,
+      muscleGroups: (json['muscle_groups'] as List?)?.cast<String>(),
+      equipment: json['equipment'] as String?,
+      exerciseType: (json['exercise_type'] ?? 'weighted') as String,
+      description: json['description'] as String?,
+      descriptionEn: json['description_en'] as String?,
+      isCustom: (json['is_custom'] ?? false) as bool,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'name_en': nameEn,
+        'muscle_groups': muscleGroups,
+        'equipment': equipment,
+        'exercise_type': exerciseType,
+        'description': description,
+        'description_en': descriptionEn,
+        'is_custom': isCustom,
+      };
+}

--- a/app/lib/features/workout/domain/exercise_log.dart
+++ b/app/lib/features/workout/domain/exercise_log.dart
@@ -1,0 +1,95 @@
+import 'package:fitness_ai/features/workout/domain/set_log.dart';
+
+/// A logged exercise within a workout session.
+class ExerciseLog {
+  const ExerciseLog({
+    required this.exerciseId,
+    required this.exerciseName,
+    required this.sets,
+    this.exerciseType = 'weighted',
+    this.muscleGroup = '',
+    this.restSeconds = 90,
+    this.skipped = false,
+    this.notes = '',
+  });
+
+  final String exerciseId;
+  final String exerciseName;
+  final String exerciseType;
+  final String muscleGroup;
+  final int restSeconds;
+  final List<SetLog> sets;
+  final bool skipped;
+  final String notes;
+
+  ExerciseLog copyWith({
+    String? exerciseId,
+    String? exerciseName,
+    String? exerciseType,
+    String? muscleGroup,
+    int? restSeconds,
+    List<SetLog>? sets,
+    bool? skipped,
+    String? notes,
+  }) {
+    return ExerciseLog(
+      exerciseId: exerciseId ?? this.exerciseId,
+      exerciseName: exerciseName ?? this.exerciseName,
+      exerciseType: exerciseType ?? this.exerciseType,
+      muscleGroup: muscleGroup ?? this.muscleGroup,
+      restSeconds: restSeconds ?? this.restSeconds,
+      sets: sets ?? this.sets,
+      skipped: skipped ?? this.skipped,
+      notes: notes ?? this.notes,
+    );
+  }
+
+  /// All sets completed (or exercise skipped).
+  bool get isComplete =>
+      skipped || (sets.isNotEmpty && sets.every((s) => s.completed));
+
+  /// Number of completed sets.
+  int get completedSetsCount => sets.where((s) => s.completed).length;
+
+  factory ExerciseLog.fromJson(Map<String, dynamic> json) {
+    return ExerciseLog(
+      exerciseId: (json['exercise_id'] ?? json['exerciseId'] ?? '').toString(),
+      exerciseName:
+          (json['exercise_name'] ?? json['exerciseName'] ?? '') as String,
+      exerciseType:
+          (json['exercise_type'] ?? json['exerciseType'] ?? 'weighted')
+              as String,
+      muscleGroup:
+          (json['muscle_group'] ?? json['muscleGroup'] ?? '') as String,
+      restSeconds:
+          (json['rest_seconds'] ?? json['restSeconds'] ?? 90) as int,
+      sets: ((json['sets'] ?? []) as List)
+          .map((s) => SetLog.fromJson(s as Map<String, dynamic>))
+          .toList(),
+      skipped: (json['skipped'] ?? false) as bool,
+      notes: (json['notes'] ?? '') as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'exercise_id': exerciseId,
+        'exercise_name': exerciseName,
+        'exercise_type': exerciseType,
+        'muscle_group': muscleGroup,
+        'rest_seconds': restSeconds,
+        'sets': sets.map((s) => s.toJson()).toList(),
+        'skipped': skipped,
+        'notes': notes,
+      };
+
+  /// API format for creating sessions.
+  Map<String, dynamic> toApiJson() => {
+        'exercise_id': exerciseId.isNotEmpty ? exerciseId : null,
+        'exercise_name': exerciseName,
+        'sets': sets
+            .where((s) => s.completed)
+            .map((s) => s.toApiJson())
+            .toList(),
+        'notes': notes.isNotEmpty ? notes : null,
+      };
+}

--- a/app/lib/features/workout/domain/set_log.dart
+++ b/app/lib/features/workout/domain/set_log.dart
@@ -1,0 +1,78 @@
+/// A single set logged during a workout exercise.
+class SetLog {
+  const SetLog({
+    required this.setNumber,
+    required this.plannedReps,
+    this.actualReps = 0,
+    this.weight = 0,
+    this.rpe = 0,
+    this.durationSeconds = 0,
+    this.completed = false,
+    this.notes = '',
+  });
+
+  final int setNumber;
+  final int plannedReps;
+  final int actualReps;
+  final double weight;
+  final double rpe;
+  final int durationSeconds;
+  final bool completed;
+  final String notes;
+
+  SetLog copyWith({
+    int? setNumber,
+    int? plannedReps,
+    int? actualReps,
+    double? weight,
+    double? rpe,
+    int? durationSeconds,
+    bool? completed,
+    String? notes,
+  }) {
+    return SetLog(
+      setNumber: setNumber ?? this.setNumber,
+      plannedReps: plannedReps ?? this.plannedReps,
+      actualReps: actualReps ?? this.actualReps,
+      weight: weight ?? this.weight,
+      rpe: rpe ?? this.rpe,
+      durationSeconds: durationSeconds ?? this.durationSeconds,
+      completed: completed ?? this.completed,
+      notes: notes ?? this.notes,
+    );
+  }
+
+  factory SetLog.fromJson(Map<String, dynamic> json) {
+    return SetLog(
+      setNumber: (json['set_number'] ?? json['setNumber'] ?? 1) as int,
+      plannedReps: (json['planned_reps'] ?? json['plannedReps'] ?? 0) as int,
+      actualReps: (json['actual_reps'] ?? json['actualReps'] ?? 0) as int,
+      weight: (json['weight'] ?? json['weight_kg'] ?? 0).toDouble(),
+      rpe: (json['rpe'] ?? 0).toDouble(),
+      durationSeconds:
+          (json['duration_seconds'] ?? json['durationSeconds'] ?? 0) as int,
+      completed: (json['completed'] ?? false) as bool,
+      notes: (json['notes'] ?? '') as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'set_number': setNumber,
+        'planned_reps': plannedReps,
+        'actual_reps': actualReps,
+        'weight': weight,
+        'rpe': rpe,
+        'duration_seconds': durationSeconds,
+        'completed': completed,
+        'notes': notes,
+      };
+
+  /// API format for creating sessions.
+  Map<String, dynamic> toApiJson() => {
+        'set_number': setNumber,
+        'weight_kg': weight > 0 ? weight : null,
+        'reps': actualReps > 0 ? actualReps : null,
+        'duration_seconds': durationSeconds > 0 ? durationSeconds : null,
+        'rpe': rpe > 0 ? rpe : null,
+      };
+}

--- a/app/lib/features/workout/domain/workout_plan.dart
+++ b/app/lib/features/workout/domain/workout_plan.dart
@@ -1,0 +1,120 @@
+/// A workout plan with days and exercises.
+class WorkoutPlan {
+  const WorkoutPlan({
+    required this.id,
+    required this.name,
+    required this.days,
+    this.description,
+    this.isActive = true,
+    this.source = 'manual',
+    this.phases,
+    this.createdAt,
+  });
+
+  final String id;
+  final String name;
+  final String? description;
+  final List<WorkoutDay> days;
+  final bool isActive;
+  final String source;
+  final List<Map<String, dynamic>>? phases;
+  final DateTime? createdAt;
+
+  factory WorkoutPlan.fromJson(Map<String, dynamic> json) {
+    return WorkoutPlan(
+      id: json['id'].toString(),
+      name: json['name'] as String,
+      description: json['description'] as String?,
+      days: ((json['days'] ?? []) as List)
+          .map((d) => WorkoutDay.fromJson(d as Map<String, dynamic>))
+          .toList(),
+      isActive: (json['is_active'] ?? true) as bool,
+      source: (json['source'] ?? 'manual') as String,
+      phases: (json['phases'] as List?)
+          ?.map((p) => p as Map<String, dynamic>)
+          .toList(),
+      createdAt: json['created_at'] != null
+          ? DateTime.parse(json['created_at'].toString())
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        'days': days.map((d) => d.toJson()).toList(),
+        'is_active': isActive,
+        'source': source,
+        'phases': phases,
+        'created_at': createdAt?.toIso8601String(),
+      };
+}
+
+/// A single day within a workout plan.
+class WorkoutDay {
+  const WorkoutDay({
+    required this.name,
+    required this.exercises,
+  });
+
+  final String name;
+  final List<PlannedExercise> exercises;
+
+  factory WorkoutDay.fromJson(Map<String, dynamic> json) {
+    return WorkoutDay(
+      name: json['name'] as String,
+      exercises: ((json['exercises'] ?? []) as List)
+          .map((e) => PlannedExercise.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'exercises': exercises.map((e) => e.toJson()).toList(),
+      };
+}
+
+/// An exercise entry in a workout plan day.
+class PlannedExercise {
+  const PlannedExercise({
+    required this.exerciseName,
+    this.exerciseId,
+    this.sets = 3,
+    this.reps = '10',
+    this.restSeconds = 90,
+    this.exerciseType = 'weighted',
+    this.notes,
+  });
+
+  final String? exerciseId;
+  final String exerciseName;
+  final int sets;
+  final String reps;
+  final int restSeconds;
+  final String exerciseType;
+  final String? notes;
+
+  factory PlannedExercise.fromJson(Map<String, dynamic> json) {
+    return PlannedExercise(
+      exerciseId: json['exercise_id']?.toString(),
+      exerciseName: (json['exercise_name'] ?? json['name'] ?? '') as String,
+      sets: (json['sets'] ?? 3) as int,
+      reps: (json['reps'] ?? '10').toString(),
+      restSeconds: (json['rest_seconds'] ?? 90) as int,
+      exerciseType: (json['exercise_type'] ?? 'weighted') as String,
+      notes: json['notes'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'exercise_id': exerciseId,
+        'exercise_name': exerciseName,
+        'sets': sets,
+        'reps': reps,
+        'rest_seconds': restSeconds,
+        'exercise_type': exerciseType,
+        'notes': notes,
+      };
+}

--- a/app/lib/features/workout/domain/workout_session.dart
+++ b/app/lib/features/workout/domain/workout_session.dart
@@ -1,0 +1,114 @@
+import 'package:fitness_ai/features/workout/domain/exercise_log.dart';
+
+/// A workout session in progress or completed.
+class WorkoutSession {
+  const WorkoutSession({
+    required this.id,
+    required this.startedAt,
+    required this.exercises,
+    this.planId,
+    this.dayName,
+    this.completedAt,
+    this.durationSeconds,
+    this.notes = '',
+    this.synced = false,
+  });
+
+  final String id;
+  final String? planId;
+  final String? dayName;
+  final DateTime startedAt;
+  final DateTime? completedAt;
+  final int? durationSeconds;
+  final List<ExerciseLog> exercises;
+  final String notes;
+  final bool synced;
+
+  bool get isCompleted => completedAt != null;
+
+  /// Total volume (weight * reps) across all exercises.
+  double get totalVolume => exercises
+      .where((e) => !e.skipped)
+      .expand((e) => e.sets)
+      .where((s) => s.completed)
+      .fold(0.0, (sum, s) => sum + (s.weight * s.actualReps));
+
+  /// Total completed sets across all exercises.
+  int get totalCompletedSets => exercises
+      .where((e) => !e.skipped)
+      .expand((e) => e.sets)
+      .where((s) => s.completed)
+      .length;
+
+  /// Number of completed exercises (all sets done or skipped).
+  int get completedExercises => exercises.where((e) => e.isComplete).length;
+
+  /// Session duration formatted as "Xh Xm" or "Xm".
+  String get formattedDuration {
+    final seconds =
+        durationSeconds ?? completedAt?.difference(startedAt).inSeconds ?? 0;
+    final minutes = seconds ~/ 60;
+    if (minutes >= 60) {
+      return '${minutes ~/ 60}h ${minutes % 60}m';
+    }
+    return '${minutes}m';
+  }
+
+  WorkoutSession copyWith({
+    String? id,
+    String? planId,
+    String? dayName,
+    DateTime? startedAt,
+    DateTime? completedAt,
+    int? durationSeconds,
+    List<ExerciseLog>? exercises,
+    String? notes,
+    bool? synced,
+  }) {
+    return WorkoutSession(
+      id: id ?? this.id,
+      planId: planId ?? this.planId,
+      dayName: dayName ?? this.dayName,
+      startedAt: startedAt ?? this.startedAt,
+      completedAt: completedAt ?? this.completedAt,
+      durationSeconds: durationSeconds ?? this.durationSeconds,
+      exercises: exercises ?? this.exercises,
+      notes: notes ?? this.notes,
+      synced: synced ?? this.synced,
+    );
+  }
+
+  factory WorkoutSession.fromJson(Map<String, dynamic> json) {
+    return WorkoutSession(
+      id: json['id'].toString(),
+      planId: json['plan_id']?.toString(),
+      dayName: json['day_name'] as String?,
+      startedAt: json['started_at'] is DateTime
+          ? json['started_at'] as DateTime
+          : DateTime.parse(json['started_at'].toString()),
+      completedAt: json['completed_at'] != null
+          ? (json['completed_at'] is DateTime
+              ? json['completed_at'] as DateTime
+              : DateTime.parse(json['completed_at'].toString()))
+          : null,
+      durationSeconds: json['duration_seconds'] as int?,
+      exercises: ((json['exercises'] ?? []) as List)
+          .map((e) => ExerciseLog.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      notes: (json['notes'] ?? '') as String,
+      synced: (json['synced'] ?? false) as bool,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'plan_id': planId,
+        'day_name': dayName,
+        'started_at': startedAt.toIso8601String(),
+        'completed_at': completedAt?.toIso8601String(),
+        'duration_seconds': durationSeconds,
+        'exercises': exercises.map((e) => e.toJson()).toList(),
+        'notes': notes,
+        'synced': synced,
+      };
+}

--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -1,0 +1,303 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fitness_ai/features/workout/data/workout_repository.dart';
+import 'package:fitness_ai/features/workout/domain/exercise_log.dart';
+import 'package:fitness_ai/features/workout/domain/set_log.dart';
+import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+
+/// State for the active workout session.
+class ActiveSessionState {
+  const ActiveSessionState({
+    required this.session,
+    this.currentExerciseIndex = 0,
+    this.isCompleted = false,
+  });
+
+  final WorkoutSession session;
+  final int currentExerciseIndex;
+  final bool isCompleted;
+
+  ExerciseLog? get currentExercise {
+    if (currentExerciseIndex >= session.exercises.length) return null;
+    return session.exercises[currentExerciseIndex];
+  }
+
+  int get totalExercises => session.exercises.length;
+  int get completedExercises => session.exercises
+      .where((e) => e.skipped || e.sets.every((s) => s.completed))
+      .length;
+
+  ActiveSessionState copyWith({
+    WorkoutSession? session,
+    int? currentExerciseIndex,
+    bool? isCompleted,
+  }) {
+    return ActiveSessionState(
+      session: session ?? this.session,
+      currentExerciseIndex: currentExerciseIndex ?? this.currentExerciseIndex,
+      isCompleted: isCompleted ?? this.isCompleted,
+    );
+  }
+}
+
+/// Manages the active workout session state.
+class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
+  @override
+  ActiveSessionState? build() => null;
+
+  WorkoutRepository get _repo => ref.read(workoutRepositoryProvider);
+
+  /// Start a new session from a workout day plan.
+  void startSession(WorkoutDay day, {String? planId}) {
+    final exercises = day.exercises.map((ep) {
+      final repsInt = int.tryParse(ep.reps) ?? 10;
+      return ExerciseLog(
+        exerciseId: ep.exerciseId ?? '',
+        exerciseName: ep.exerciseName,
+        exerciseType: ep.exerciseType,
+        restSeconds: ep.restSeconds,
+        sets: List.generate(
+          ep.sets,
+          (i) => SetLog(setNumber: i + 1, plannedReps: repsInt),
+        ),
+      );
+    }).toList();
+
+    final session = WorkoutSession(
+      id: _repo.generateSessionId(),
+      planId: planId,
+      dayName: day.name,
+      startedAt: DateTime.now(),
+      exercises: exercises,
+    );
+
+    state = ActiveSessionState(session: session);
+    _save();
+  }
+
+  /// Log weight and reps for a specific set.
+  void logSet({
+    required int exerciseIndex,
+    required int setIndex,
+    required double weight,
+    required int reps,
+  }) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    final exercise = exercises[exerciseIndex];
+    final sets = List<SetLog>.from(exercise.sets);
+
+    sets[setIndex] = sets[setIndex].copyWith(
+      weight: weight,
+      actualReps: reps,
+      completed: true,
+    );
+    exercises[exerciseIndex] = exercise.copyWith(sets: sets);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Log duration for a timed exercise set.
+  void logTimedSet({
+    required int exerciseIndex,
+    required int setIndex,
+    required int durationSeconds,
+  }) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    final exercise = exercises[exerciseIndex];
+    final sets = List<SetLog>.from(exercise.sets);
+
+    sets[setIndex] = sets[setIndex].copyWith(
+      durationSeconds: durationSeconds,
+      completed: true,
+    );
+    exercises[exerciseIndex] = exercise.copyWith(sets: sets);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Log a bodyweight set (reps only, no weight).
+  void logBodyweightSet({
+    required int exerciseIndex,
+    required int setIndex,
+    required int reps,
+  }) {
+    logSet(
+      exerciseIndex: exerciseIndex,
+      setIndex: setIndex,
+      weight: 0,
+      reps: reps,
+    );
+  }
+
+  /// Undo a completed set.
+  void undoSet({required int exerciseIndex, required int setIndex}) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    final exercise = exercises[exerciseIndex];
+    final sets = List<SetLog>.from(exercise.sets);
+
+    sets[setIndex] = sets[setIndex].copyWith(completed: false);
+    exercises[exerciseIndex] = exercise.copyWith(sets: sets);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Skip an exercise.
+  void skipExercise(int exerciseIndex) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    exercises[exerciseIndex] =
+        exercises[exerciseIndex].copyWith(skipped: true);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Unskip a previously skipped exercise.
+  void unskipExercise(int exerciseIndex) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    exercises[exerciseIndex] =
+        exercises[exerciseIndex].copyWith(skipped: false);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Add a new set to an exercise (copies weight from last set).
+  void addSet({required int exerciseIndex}) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    final exercise = exercises[exerciseIndex];
+    final sets = List<SetLog>.from(exercise.sets);
+
+    final lastSet = sets.last;
+    sets.add(SetLog(
+      setNumber: sets.length + 1,
+      plannedReps: lastSet.plannedReps,
+      weight: lastSet.weight,
+    ));
+    exercises[exerciseIndex] = exercise.copyWith(sets: sets);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Remove a set from an exercise (minimum 1 set).
+  void removeSet({required int exerciseIndex, required int setIndex}) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    final exercise = exercises[exerciseIndex];
+    final sets = List<SetLog>.from(exercise.sets);
+
+    if (sets.length <= 1) return;
+    sets.removeAt(setIndex);
+    // Renumber
+    for (var i = 0; i < sets.length; i++) {
+      sets[i] = sets[i].copyWith(setNumber: i + 1);
+    }
+    exercises[exerciseIndex] = exercise.copyWith(sets: sets);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Add a custom exercise to the current session.
+  void addCustomExercise({
+    required String name,
+    required int sets,
+    required int reps,
+    String exerciseType = 'weighted',
+  }) {
+    final s = state;
+    if (s == null) return;
+
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    exercises.add(ExerciseLog(
+      exerciseId: 'custom-${DateTime.now().millisecondsSinceEpoch}',
+      exerciseName: name,
+      exerciseType: exerciseType,
+      sets: List.generate(
+          sets, (i) => SetLog(setNumber: i + 1, plannedReps: reps)),
+    ));
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
+  /// Move to a specific exercise index.
+  void goToExercise(int index) {
+    final s = state;
+    if (s == null) return;
+    if (index < 0 || index >= s.session.exercises.length) return;
+    state = s.copyWith(currentExerciseIndex: index);
+  }
+
+  /// Complete the workout session.
+  void completeSession() {
+    final s = state;
+    if (s == null) return;
+
+    final duration = DateTime.now().difference(s.session.startedAt).inSeconds;
+    state = s.copyWith(
+      session: s.session.copyWith(
+        completedAt: DateTime.now(),
+        durationSeconds: duration,
+      ),
+      isCompleted: true,
+    );
+    _save();
+  }
+
+  /// Close and discard the active session UI.
+  void closeSession() {
+    state = null;
+  }
+
+  Future<void> _save() async {
+    final s = state;
+    if (s == null) return;
+    await _repo.saveSessionLocally(s.session);
+  }
+}
+
+/// Provider for the active workout session.
+final activeSessionProvider =
+    NotifierProvider<ActiveSessionNotifier, ActiveSessionState?>(
+        ActiveSessionNotifier.new);

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -1,0 +1,465 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fitness_ai/core/services/rest_timer_service.dart';
+import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/workout/domain/exercise_log.dart';
+import 'package:fitness_ai/features/workout/presentation/active_session_notifier.dart';
+import 'package:fitness_ai/features/workout/presentation/rest_timer_overlay.dart';
+import 'package:fitness_ai/features/workout/presentation/set_input_row.dart';
+
+/// Active workout screen with inline set tracker (Strong-style).
+/// Shows all exercises with expandable set rows, rest timer, and
+/// session controls.
+class ActiveWorkoutScreen extends ConsumerStatefulWidget {
+  const ActiveWorkoutScreen({super.key});
+
+  @override
+  ConsumerState<ActiveWorkoutScreen> createState() =>
+      _ActiveWorkoutScreenState();
+}
+
+class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
+  final _restTimer = RestTimerService();
+  bool _showTimer = false;
+  String? _lastExerciseName;
+  int? _lastSetNumber;
+  int? _lastTotalSets;
+
+  @override
+  void dispose() {
+    _restTimer.dispose();
+    super.dispose();
+  }
+
+  void _onSetCompleted(ExerciseLog exercise, int exerciseIndex, int setIndex) {
+    _lastExerciseName = exercise.exerciseName;
+    _lastSetNumber = setIndex + 1;
+    _lastTotalSets = exercise.sets.length;
+    if (exercise.restSeconds > 0) {
+      _restTimer.start(exercise.restSeconds);
+      setState(() => _showTimer = true);
+    }
+  }
+
+  void _finishWorkout() {
+    final notifier = ref.read(activeSessionProvider.notifier);
+    notifier.completeSession();
+
+    // Show completion dialog
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) {
+        final session = ref.read(activeSessionProvider)?.session;
+        return AlertDialog(
+          backgroundColor: AppColors.bgSecondary,
+          title: const GradientText(
+            'Allenamento completato!',
+            style: TextStyle(fontSize: 22, fontWeight: FontWeight.w800),
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (session != null) ...[
+                _SummaryRow(
+                    label: 'Durata', value: session.formattedDuration),
+                _SummaryRow(
+                    label: 'Serie completate',
+                    value: '${session.totalCompletedSets}'),
+                _SummaryRow(
+                    label: 'Volume totale',
+                    value: '${session.totalVolume.toStringAsFixed(0)} kg'),
+              ],
+            ],
+          ),
+          actions: [
+            GlowButton(
+              label: 'Chiudi',
+              onPressed: () {
+                Navigator.of(ctx).pop();
+                notifier.closeSession();
+                Navigator.of(context).pop();
+              },
+              color: AppColors.success,
+              height: 48,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sessionState = ref.watch(activeSessionProvider);
+    if (sessionState == null) {
+      return const Scaffold(
+        body: Center(child: Text('Nessuna sessione attiva')),
+      );
+    }
+
+    final session = sessionState.session;
+    final elapsed = DateTime.now().difference(session.startedAt);
+    final elapsedMin = elapsed.inMinutes;
+
+    return Scaffold(
+      body: Stack(
+        children: [
+          SafeArea(
+            child: Column(
+              children: [
+                // Header bar
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.md,
+                    vertical: AppSpacing.sm,
+                  ),
+                  child: Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.close),
+                        onPressed: () => _showCancelDialog(),
+                      ),
+                      Expanded(
+                        child: Column(
+                          children: [
+                            Text(
+                              session.dayName ?? 'Workout',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            Text(
+                              '${elapsedMin}min - ${sessionState.completedExercises}/${sessionState.totalExercises} esercizi',
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                          ],
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: _finishWorkout,
+                        child: const Text(
+                          'FINE',
+                          style: TextStyle(
+                            color: AppColors.success,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                // Exercise list
+                Expanded(
+                  child: ListView.builder(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+                    itemCount: session.exercises.length + 1, // +1 for add button
+                    itemBuilder: (context, index) {
+                      if (index == session.exercises.length) {
+                        return _AddExerciseButton(
+                          onAdd: () => _showAddExerciseDialog(),
+                        );
+                      }
+                      return _ExerciseCard(
+                        exercise: session.exercises[index],
+                        exerciseIndex: index,
+                        onSetCompleted: (setIndex) => _onSetCompleted(
+                          session.exercises[index],
+                          index,
+                          setIndex,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Rest timer overlay
+          if (_showTimer)
+            RestTimerOverlay(
+              timer: _restTimer,
+              exerciseName: _lastExerciseName,
+              currentSet: _lastSetNumber,
+              totalSets: _lastTotalSets,
+              onSkip: () {
+                _restTimer.skip();
+                setState(() => _showTimer = false);
+              },
+              onAddThirty: () => _restTimer.addThirtySeconds(),
+              onDismiss: () => setState(() => _showTimer = false),
+            ),
+        ],
+      ),
+    );
+  }
+
+  void _showCancelDialog() {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.bgSecondary,
+        title: const Text('Annullare il workout?'),
+        content: const Text('I dati della sessione verranno persi.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Continua'),
+          ),
+          TextButton(
+            onPressed: () {
+              ref.read(activeSessionProvider.notifier).closeSession();
+              Navigator.of(ctx).pop();
+              Navigator.of(context).pop();
+            },
+            child: const Text('Annulla workout',
+                style: TextStyle(color: AppColors.error)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showAddExerciseDialog() {
+    final nameController = TextEditingController();
+    final setsController = TextEditingController(text: '3');
+    final repsController = TextEditingController(text: '10');
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.bgSecondary,
+        title: const Text('Aggiungi esercizio'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(hintText: 'Nome esercizio'),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: setsController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(hintText: 'Serie'),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: TextField(
+                    controller: repsController,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(hintText: 'Reps'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Annulla'),
+          ),
+          TextButton(
+            onPressed: () {
+              if (nameController.text.isNotEmpty) {
+                ref.read(activeSessionProvider.notifier).addCustomExercise(
+                      name: nameController.text,
+                      sets: int.tryParse(setsController.text) ?? 3,
+                      reps: int.tryParse(repsController.text) ?? 10,
+                    );
+              }
+              Navigator.of(ctx).pop();
+            },
+            child: const Text('Aggiungi',
+                style: TextStyle(color: AppColors.primary)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Card for a single exercise showing all its sets inline.
+class _ExerciseCard extends ConsumerWidget {
+  const _ExerciseCard({
+    required this.exercise,
+    required this.exerciseIndex,
+    required this.onSetCompleted,
+  });
+
+  final ExerciseLog exercise;
+  final int exerciseIndex;
+  final void Function(int setIndex) onSetCompleted;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return GlassmorphismCard(
+      margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+      borderColor: exercise.isComplete
+          ? AppColors.success.withValues(alpha: 0.3)
+          : exercise.skipped
+              ? AppColors.textDisabled.withValues(alpha: 0.2)
+              : AppColors.primary.withValues(alpha: 0.1),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Exercise header
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  exercise.exerciseName,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: exercise.skipped
+                            ? AppColors.textDisabled
+                            : null,
+                        decoration:
+                            exercise.skipped ? TextDecoration.lineThrough : null,
+                      ),
+                ),
+              ),
+              // Skip / Unskip
+              IconButton(
+                icon: Icon(
+                  exercise.skipped ? Icons.undo : Icons.skip_next,
+                  color: AppColors.textSecondary,
+                  size: 20,
+                ),
+                onPressed: () {
+                  if (exercise.skipped) {
+                    ref
+                        .read(activeSessionProvider.notifier)
+                        .unskipExercise(exerciseIndex);
+                  } else {
+                    ref
+                        .read(activeSessionProvider.notifier)
+                        .skipExercise(exerciseIndex);
+                  }
+                },
+              ),
+            ],
+          ),
+          if (!exercise.skipped) ...[
+            const SizedBox(height: AppSpacing.sm),
+            // Set header row
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+              child: Row(
+                children: [
+                  const SizedBox(width: 32, child: Text('SET', style: _headerStyle)),
+                  if (exercise.exerciseType == 'weighted') ...[
+                    const Expanded(child: Text('KG', style: _headerStyle, textAlign: TextAlign.center)),
+                    const Expanded(child: Text('REPS', style: _headerStyle, textAlign: TextAlign.center)),
+                  ] else if (exercise.exerciseType == 'timed') ...[
+                    const Expanded(child: Text('SEC', style: _headerStyle, textAlign: TextAlign.center)),
+                  ] else ...[
+                    const Expanded(child: Text('REPS', style: _headerStyle, textAlign: TextAlign.center)),
+                  ],
+                  const SizedBox(width: 36),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            // Set rows
+            ...exercise.sets.asMap().entries.map((entry) {
+              return SetInputRow(
+                setLog: entry.value,
+                exerciseType: exercise.exerciseType,
+                exerciseIndex: exerciseIndex,
+                setIndex: entry.key,
+                onCompleted: () => onSetCompleted(entry.key),
+              );
+            }),
+            // Add/remove set controls
+            const SizedBox(height: AppSpacing.xs),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton.icon(
+                  onPressed: () => ref
+                      .read(activeSessionProvider.notifier)
+                      .addSet(exerciseIndex: exerciseIndex),
+                  icon: const Icon(Icons.add, size: 16),
+                  label: const Text('Serie'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: AppColors.primary,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+const _headerStyle = TextStyle(
+  color: AppColors.textSecondary,
+  fontSize: 11,
+  fontWeight: FontWeight.w600,
+  letterSpacing: 0.5,
+);
+
+/// Summary row in the completion dialog.
+class _SummaryRow extends StatelessWidget {
+  const _SummaryRow({required this.label, required this.value});
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: Theme.of(context).textTheme.bodyMedium),
+          Text(value,
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(color: AppColors.primary)),
+        ],
+      ),
+    );
+  }
+}
+
+/// Button to add a custom exercise during workout.
+class _AddExerciseButton extends StatelessWidget {
+  const _AddExerciseButton({required this.onAdd});
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+      child: GlassmorphismCard(
+        onTap: onAdd,
+        borderColor: AppColors.primary.withValues(alpha: 0.1),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.add, color: AppColors.primary, size: 20),
+            const SizedBox(width: AppSpacing.sm),
+            Text(
+              'Aggiungi esercizio',
+              style: Theme.of(context)
+                  .textTheme
+                  .labelLarge
+                  ?.copyWith(color: AppColors.primary),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/workout/presentation/rest_timer_overlay.dart
+++ b/app/lib/features/workout/presentation/rest_timer_overlay.dart
@@ -1,0 +1,221 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'package:fitness_ai/core/services/rest_timer_service.dart';
+import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
+
+/// Full-screen rest timer overlay with animated progress ring.
+/// Shows countdown between sets with skip and +30s controls.
+class RestTimerOverlay extends StatelessWidget {
+  const RestTimerOverlay({
+    super.key,
+    required this.timer,
+    required this.onSkip,
+    required this.onAddThirty,
+    required this.onDismiss,
+    this.exerciseName,
+    this.currentSet,
+    this.totalSets,
+  });
+
+  final RestTimerService timer;
+  final VoidCallback onSkip;
+  final VoidCallback onAddThirty;
+  final VoidCallback onDismiss;
+  final String? exerciseName;
+  final int? currentSet;
+  final int? totalSets;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: timer,
+      builder: (context, _) {
+        if (!timer.isRunning && timer.remainingSeconds == 0) {
+          return const SizedBox.shrink();
+        }
+
+        return GestureDetector(
+          onTap: onDismiss,
+          child: Container(
+            color: AppColors.bgPrimary.withValues(alpha: 0.95),
+            child: SafeArea(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'RECUPERO',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: AppColors.textSecondary,
+                          letterSpacing: 2,
+                        ),
+                  ),
+                  if (exerciseName != null && currentSet != null) ...[
+                    const SizedBox(height: AppSpacing.sm),
+                    Text(
+                      'Serie $currentSet/$totalSets - $exerciseName',
+                      style: const TextStyle(
+                        color: AppColors.primary,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                  const SizedBox(height: AppSpacing.xl),
+                  // Progress ring with countdown
+                  SizedBox(
+                    width: 200,
+                    height: 200,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        CustomPaint(
+                          size: const Size(200, 200),
+                          painter: _TimerRingPainter(
+                            progress: timer.progress,
+                            backgroundColor: AppColors.bgElevated,
+                            progressColor: timer.remainingSeconds <= 5
+                                ? AppColors.warning
+                                : AppColors.primary,
+                          ),
+                        ),
+                        Text(
+                          timer.formattedTime,
+                          style: TextStyle(
+                            fontSize: 48,
+                            fontWeight: FontWeight.w900,
+                            color: timer.remainingSeconds <= 5
+                                ? AppColors.warning
+                                : AppColors.textPrimary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xl),
+                  // Action buttons
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _TimerButton(
+                        label: 'Salta',
+                        icon: Icons.skip_next,
+                        color: AppColors.textSecondary,
+                        onPressed: onSkip,
+                      ),
+                      const SizedBox(width: AppSpacing.xl),
+                      _TimerButton(
+                        label: '+30s',
+                        icon: Icons.add,
+                        color: AppColors.primary,
+                        onPressed: onAddThirty,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _TimerButton extends StatelessWidget {
+  const _TimerButton({
+    required this.label,
+    required this.icon,
+    required this.color,
+    required this.onPressed,
+  });
+
+  final String label;
+  final IconData icon;
+  final Color color;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onPressed,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.md,
+        ),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(AppSpacing.radiusFull),
+          border: Border.all(color: color.withValues(alpha: 0.3)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: color, size: 20),
+            const SizedBox(width: AppSpacing.sm),
+            Text(
+              label,
+              style: TextStyle(
+                color: color,
+                fontWeight: FontWeight.w600,
+                fontSize: 16,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Custom painter for the timer progress ring.
+class _TimerRingPainter extends CustomPainter {
+  _TimerRingPainter({
+    required this.progress,
+    required this.backgroundColor,
+    required this.progressColor,
+  });
+
+  final double progress;
+  final Color backgroundColor;
+  final Color progressColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width / 2 - 8;
+    const strokeWidth = 6.0;
+
+    final bgPaint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawCircle(center, radius, bgPaint);
+
+    final progressPaint = Paint()
+      ..color = progressColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      -math.pi / 2,
+      2 * math.pi * progress,
+      false,
+      progressPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _TimerRingPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.progressColor != progressColor;
+  }
+}

--- a/app/lib/features/workout/presentation/set_input_row.dart
+++ b/app/lib/features/workout/presentation/set_input_row.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/workout/domain/set_log.dart';
+import 'package:fitness_ai/features/workout/presentation/active_session_notifier.dart';
+
+/// Inline set input row (Strong-style).
+/// Shows set number, weight/reps inputs, and completion checkbox.
+/// Supports weighted, timed, and bodyweight exercise types.
+class SetInputRow extends ConsumerStatefulWidget {
+  const SetInputRow({
+    super.key,
+    required this.setLog,
+    required this.exerciseType,
+    required this.exerciseIndex,
+    required this.setIndex,
+    required this.onCompleted,
+  });
+
+  final SetLog setLog;
+  final String exerciseType;
+  final int exerciseIndex;
+  final int setIndex;
+  final VoidCallback onCompleted;
+
+  @override
+  ConsumerState<SetInputRow> createState() => _SetInputRowState();
+}
+
+class _SetInputRowState extends ConsumerState<SetInputRow> {
+  late TextEditingController _weightController;
+  late TextEditingController _repsController;
+  late TextEditingController _durationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _weightController = TextEditingController(
+      text: widget.setLog.weight > 0
+          ? _formatWeight(widget.setLog.weight)
+          : '',
+    );
+    _repsController = TextEditingController(
+      text: widget.setLog.actualReps > 0
+          ? widget.setLog.actualReps.toString()
+          : widget.setLog.plannedReps.toString(),
+    );
+    _durationController = TextEditingController(
+      text: widget.setLog.durationSeconds > 0
+          ? widget.setLog.durationSeconds.toString()
+          : '30',
+    );
+  }
+
+  @override
+  void didUpdateWidget(SetInputRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Update controllers when weight changes externally (e.g., pre-fill)
+    if (widget.setLog.weight != oldWidget.setLog.weight &&
+        widget.setLog.weight > 0) {
+      _weightController.text = _formatWeight(widget.setLog.weight);
+    }
+  }
+
+  @override
+  void dispose() {
+    _weightController.dispose();
+    _repsController.dispose();
+    _durationController.dispose();
+    super.dispose();
+  }
+
+  String _formatWeight(double w) {
+    return w == w.roundToDouble() ? w.toInt().toString() : w.toString();
+  }
+
+  void _completeSet() {
+    final notifier = ref.read(activeSessionProvider.notifier);
+
+    switch (widget.exerciseType) {
+      case 'weighted':
+        final weight = double.tryParse(_weightController.text) ?? 0;
+        final reps = int.tryParse(_repsController.text) ?? 0;
+        notifier.logSet(
+          exerciseIndex: widget.exerciseIndex,
+          setIndex: widget.setIndex,
+          weight: weight,
+          reps: reps,
+        );
+        break;
+      case 'timed':
+        final duration = int.tryParse(_durationController.text) ?? 0;
+        notifier.logTimedSet(
+          exerciseIndex: widget.exerciseIndex,
+          setIndex: widget.setIndex,
+          durationSeconds: duration,
+        );
+        break;
+      case 'bodyweight':
+        final reps = int.tryParse(_repsController.text) ?? 0;
+        notifier.logBodyweightSet(
+          exerciseIndex: widget.exerciseIndex,
+          setIndex: widget.setIndex,
+          reps: reps,
+        );
+        break;
+    }
+
+    widget.onCompleted();
+  }
+
+  void _undoSet() {
+    ref.read(activeSessionProvider.notifier).undoSet(
+          exerciseIndex: widget.exerciseIndex,
+          setIndex: widget.setIndex,
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isCompleted = widget.setLog.completed;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: isCompleted
+            ? AppColors.success.withValues(alpha: 0.08)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+      child: Row(
+        children: [
+          // Set number badge
+          SizedBox(
+            width: 32,
+            child: Center(
+              child: Text(
+                widget.setLog.setNumber.toString(),
+                style: TextStyle(
+                  color: isCompleted
+                      ? AppColors.success
+                      : AppColors.textSecondary,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 14,
+                ),
+              ),
+            ),
+          ),
+          // Input fields based on exercise type
+          if (widget.exerciseType == 'weighted') ...[
+            Expanded(
+              child: _CompactInput(
+                controller: _weightController,
+                enabled: !isCompleted,
+                suffix: 'kg',
+              ),
+            ),
+            Expanded(
+              child: _CompactInput(
+                controller: _repsController,
+                enabled: !isCompleted,
+              ),
+            ),
+          ] else if (widget.exerciseType == 'timed') ...[
+            Expanded(
+              child: _CompactInput(
+                controller: _durationController,
+                enabled: !isCompleted,
+                suffix: 's',
+              ),
+            ),
+          ] else ...[
+            // bodyweight
+            Expanded(
+              child: _CompactInput(
+                controller: _repsController,
+                enabled: !isCompleted,
+              ),
+            ),
+          ],
+          // Completion check
+          SizedBox(
+            width: 36,
+            child: AnimatedCheck(
+              isChecked: isCompleted,
+              onTap: isCompleted ? _undoSet : _completeSet,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Compact number input for the set row.
+class _CompactInput extends StatelessWidget {
+  const _CompactInput({
+    required this.controller,
+    this.enabled = true,
+    this.suffix,
+  });
+
+  final TextEditingController controller;
+  final bool enabled;
+  final String? suffix;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: TextField(
+        controller: controller,
+        enabled: enabled,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.w700,
+          color: enabled ? AppColors.textPrimary : AppColors.textSecondary,
+        ),
+        decoration: InputDecoration(
+          isDense: true,
+          contentPadding: const EdgeInsets.symmetric(
+            vertical: AppSpacing.sm,
+            horizontal: AppSpacing.xs,
+          ),
+          filled: true,
+          fillColor: enabled
+              ? AppColors.bgElevated.withValues(alpha: 0.5)
+              : Colors.transparent,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+            borderSide: BorderSide.none,
+          ),
+          suffixText: suffix,
+          suffixStyle: const TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 12,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/test/features/workout/exercise_log_test.dart
+++ b/app/test/features/workout/exercise_log_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fitness_ai/features/workout/domain/exercise_log.dart';
+import 'package:fitness_ai/features/workout/domain/set_log.dart';
+
+void main() {
+  group('ExerciseLog', () {
+    test('isComplete returns true when all sets completed', () {
+      final exercise = ExerciseLog(
+        exerciseId: 'ex1',
+        exerciseName: 'Bench Press',
+        sets: [
+          const SetLog(setNumber: 1, plannedReps: 10, completed: true),
+          const SetLog(setNumber: 2, plannedReps: 10, completed: true),
+        ],
+      );
+      expect(exercise.isComplete, true);
+    });
+
+    test('isComplete returns false when sets incomplete', () {
+      final exercise = ExerciseLog(
+        exerciseId: 'ex1',
+        exerciseName: 'Bench Press',
+        sets: [
+          const SetLog(setNumber: 1, plannedReps: 10, completed: true),
+          const SetLog(setNumber: 2, plannedReps: 10, completed: false),
+        ],
+      );
+      expect(exercise.isComplete, false);
+    });
+
+    test('isComplete returns true when skipped', () {
+      final exercise = ExerciseLog(
+        exerciseId: 'ex1',
+        exerciseName: 'Bench Press',
+        skipped: true,
+        sets: [
+          const SetLog(setNumber: 1, plannedReps: 10, completed: false),
+        ],
+      );
+      expect(exercise.isComplete, true);
+    });
+
+    test('completedSetsCount counts only completed sets', () {
+      final exercise = ExerciseLog(
+        exerciseId: 'ex1',
+        exerciseName: 'Squat',
+        sets: [
+          const SetLog(setNumber: 1, plannedReps: 10, completed: true),
+          const SetLog(setNumber: 2, plannedReps: 10, completed: true),
+          const SetLog(setNumber: 3, plannedReps: 10, completed: false),
+        ],
+      );
+      expect(exercise.completedSetsCount, 2);
+    });
+
+    test('fromJson creates correct exercise', () {
+      final json = {
+        'exercise_id': 'ex1',
+        'exercise_name': 'Deadlift',
+        'exercise_type': 'weighted',
+        'rest_seconds': 120,
+        'sets': [
+          {'set_number': 1, 'planned_reps': 5, 'weight': 140.0, 'completed': true},
+        ],
+      };
+      final exercise = ExerciseLog.fromJson(json);
+      expect(exercise.exerciseName, 'Deadlift');
+      expect(exercise.restSeconds, 120);
+      expect(exercise.sets.length, 1);
+      expect(exercise.sets[0].weight, 140);
+    });
+
+    test('toApiJson excludes incomplete sets', () {
+      final exercise = ExerciseLog(
+        exerciseId: 'ex1',
+        exerciseName: 'Row',
+        sets: [
+          const SetLog(setNumber: 1, plannedReps: 10, weight: 60, actualReps: 10, completed: true),
+          const SetLog(setNumber: 2, plannedReps: 10, completed: false),
+        ],
+      );
+      final api = exercise.toApiJson();
+      final sets = api['sets'] as List;
+      expect(sets.length, 1); // Only completed set
+    });
+  });
+}

--- a/app/test/features/workout/rest_timer_test.dart
+++ b/app/test/features/workout/rest_timer_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fitness_ai/core/services/rest_timer_service.dart';
+
+void main() {
+  group('RestTimerService', () {
+    late RestTimerService timer;
+
+    setUp(() {
+      timer = RestTimerService();
+    });
+
+    tearDown(() {
+      timer.dispose();
+    });
+
+    test('initial state is not running', () {
+      expect(timer.isRunning, false);
+      expect(timer.remainingSeconds, 0);
+      expect(timer.totalSeconds, 0);
+    });
+
+    test('start sets running state', () {
+      timer.start(90);
+      expect(timer.isRunning, true);
+      expect(timer.totalSeconds, 90);
+      expect(timer.remainingSeconds, greaterThan(0));
+    });
+
+    test('formattedTime formats correctly', () {
+      timer.start(90);
+      expect(timer.formattedTime, matches(RegExp(r'\d{2}:\d{2}')));
+    });
+
+    test('progress starts near 0', () {
+      timer.start(90);
+      expect(timer.progress, lessThan(0.05));
+    });
+
+    test('skip stops the timer', () {
+      timer.start(90);
+      timer.skip();
+      expect(timer.isRunning, false);
+      expect(timer.remainingSeconds, 0);
+    });
+
+    test('stop resets the timer', () {
+      timer.start(90);
+      timer.stop();
+      expect(timer.isRunning, false);
+      expect(timer.totalSeconds, 0);
+    });
+
+    test('addThirtySeconds increases total', () {
+      timer.start(60);
+      timer.addThirtySeconds();
+      expect(timer.totalSeconds, 90);
+    });
+  });
+}

--- a/app/test/features/workout/set_log_test.dart
+++ b/app/test/features/workout/set_log_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fitness_ai/features/workout/domain/set_log.dart';
+
+void main() {
+  group('SetLog', () {
+    test('default values are correct', () {
+      const set = SetLog(setNumber: 1, plannedReps: 10);
+      expect(set.actualReps, 0);
+      expect(set.weight, 0);
+      expect(set.completed, false);
+      expect(set.durationSeconds, 0);
+    });
+
+    test('copyWith updates specified fields', () {
+      const set = SetLog(setNumber: 1, plannedReps: 10);
+      final updated = set.copyWith(weight: 80, actualReps: 10, completed: true);
+      expect(updated.weight, 80);
+      expect(updated.actualReps, 10);
+      expect(updated.completed, true);
+      expect(updated.plannedReps, 10); // unchanged
+    });
+
+    test('fromJson creates correct set', () {
+      final json = {
+        'set_number': 2,
+        'planned_reps': 8,
+        'actual_reps': 8,
+        'weight': 100.0,
+        'completed': true,
+      };
+      final set = SetLog.fromJson(json);
+      expect(set.setNumber, 2);
+      expect(set.plannedReps, 8);
+      expect(set.actualReps, 8);
+      expect(set.weight, 100);
+      expect(set.completed, true);
+    });
+
+    test('toJson roundtrip preserves data', () {
+      const set = SetLog(
+        setNumber: 1,
+        plannedReps: 10,
+        actualReps: 10,
+        weight: 80,
+        completed: true,
+      );
+      final json = set.toJson();
+      final restored = SetLog.fromJson(json);
+      expect(restored.setNumber, set.setNumber);
+      expect(restored.weight, set.weight);
+      expect(restored.completed, set.completed);
+    });
+
+    test('toApiJson uses weight_kg format', () {
+      const set = SetLog(
+        setNumber: 1,
+        plannedReps: 10,
+        actualReps: 8,
+        weight: 60,
+      );
+      final api = set.toApiJson();
+      expect(api['weight_kg'], 60);
+      expect(api['reps'], 8);
+      expect(api['set_number'], 1);
+    });
+  });
+}

--- a/app/test/features/workout/workout_plan_test.dart
+++ b/app/test/features/workout/workout_plan_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
+
+void main() {
+  group('WorkoutPlan', () {
+    test('fromJson creates plan with days', () {
+      final json = {
+        'id': 'plan-1',
+        'name': 'Push Pull Legs',
+        'description': 'A PPL split',
+        'is_active': true,
+        'source': 'manual',
+        'days': [
+          {
+            'name': 'Push Day',
+            'exercises': [
+              {
+                'exercise_name': 'Bench Press',
+                'sets': 4,
+                'reps': '8',
+                'rest_seconds': 120,
+              },
+            ],
+          },
+        ],
+      };
+      final plan = WorkoutPlan.fromJson(json);
+      expect(plan.name, 'Push Pull Legs');
+      expect(plan.days.length, 1);
+      expect(plan.days[0].name, 'Push Day');
+      expect(plan.days[0].exercises.length, 1);
+      expect(plan.days[0].exercises[0].exerciseName, 'Bench Press');
+      expect(plan.days[0].exercises[0].sets, 4);
+    });
+
+    test('toJson roundtrip preserves data', () {
+      const plan = WorkoutPlan(
+        id: 'plan-1',
+        name: 'Full Body',
+        days: [
+          WorkoutDay(
+            name: 'Day A',
+            exercises: [
+              PlannedExercise(exerciseName: 'Squat', sets: 3, reps: '5'),
+            ],
+          ),
+        ],
+      );
+      final json = plan.toJson();
+      final restored = WorkoutPlan.fromJson(json);
+      expect(restored.name, plan.name);
+      expect(restored.days[0].exercises[0].exerciseName, 'Squat');
+    });
+  });
+
+  group('PlannedExercise', () {
+    test('default values are correct', () {
+      const ex = PlannedExercise(exerciseName: 'Test');
+      expect(ex.sets, 3);
+      expect(ex.reps, '10');
+      expect(ex.restSeconds, 90);
+      expect(ex.exerciseType, 'weighted');
+    });
+
+    test('fromJson handles all fields', () {
+      final json = {
+        'exercise_id': 'ex-123',
+        'exercise_name': 'Curl',
+        'sets': 4,
+        'reps': '12',
+        'rest_seconds': 60,
+        'exercise_type': 'weighted',
+        'notes': 'Slow eccentric',
+      };
+      final ex = PlannedExercise.fromJson(json);
+      expect(ex.exerciseId, 'ex-123');
+      expect(ex.exerciseName, 'Curl');
+      expect(ex.sets, 4);
+      expect(ex.notes, 'Slow eccentric');
+    });
+  });
+}

--- a/app/test/features/workout/workout_session_test.dart
+++ b/app/test/features/workout/workout_session_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fitness_ai/features/workout/domain/exercise_log.dart';
+import 'package:fitness_ai/features/workout/domain/set_log.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+
+void main() {
+  group('WorkoutSession', () {
+    WorkoutSession createSession() {
+      return WorkoutSession(
+        id: 'session-1',
+        startedAt: DateTime(2026, 4, 2, 10, 0),
+        completedAt: DateTime(2026, 4, 2, 11, 15),
+        durationSeconds: 4500,
+        exercises: [
+          ExerciseLog(
+            exerciseId: 'ex1',
+            exerciseName: 'Bench Press',
+            sets: [
+              const SetLog(setNumber: 1, plannedReps: 10, weight: 80, actualReps: 10, completed: true),
+              const SetLog(setNumber: 2, plannedReps: 10, weight: 80, actualReps: 8, completed: true),
+            ],
+          ),
+          ExerciseLog(
+            exerciseId: 'ex2',
+            exerciseName: 'Rows',
+            sets: [
+              const SetLog(setNumber: 1, plannedReps: 10, weight: 60, actualReps: 10, completed: true),
+            ],
+          ),
+        ],
+      );
+    }
+
+    test('totalVolume calculates correctly', () {
+      final session = createSession();
+      // (80*10) + (80*8) + (60*10) = 800 + 640 + 600 = 2040
+      expect(session.totalVolume, 2040);
+    });
+
+    test('totalCompletedSets counts all completed sets', () {
+      final session = createSession();
+      expect(session.totalCompletedSets, 3);
+    });
+
+    test('completedExercises counts exercises with all sets done', () {
+      final session = createSession();
+      expect(session.completedExercises, 2);
+    });
+
+    test('formattedDuration formats correctly', () {
+      final session = createSession();
+      expect(session.formattedDuration, '1h 15m');
+    });
+
+    test('formattedDuration shows minutes only for short sessions', () {
+      final session = WorkoutSession(
+        id: 'session-2',
+        startedAt: DateTime(2026, 4, 2, 10, 0),
+        durationSeconds: 2400,
+        exercises: [],
+      );
+      expect(session.formattedDuration, '40m');
+    });
+
+    test('isCompleted returns true when completedAt is set', () {
+      final session = createSession();
+      expect(session.isCompleted, true);
+    });
+
+    test('isCompleted returns false when completedAt is null', () {
+      final session = WorkoutSession(
+        id: 'session-3',
+        startedAt: DateTime.now(),
+        exercises: [],
+      );
+      expect(session.isCompleted, false);
+    });
+
+    test('fromJson roundtrip preserves data', () {
+      final session = createSession();
+      final json = session.toJson();
+      final restored = WorkoutSession.fromJson(json);
+      expect(restored.id, session.id);
+      expect(restored.exercises.length, 2);
+      expect(restored.exercises[0].exerciseName, 'Bench Press');
+      expect(restored.totalVolume, session.totalVolume);
+    });
+
+    test('skipped exercises excluded from volume', () {
+      final session = WorkoutSession(
+        id: 'session-4',
+        startedAt: DateTime.now(),
+        exercises: [
+          ExerciseLog(
+            exerciseId: 'ex1',
+            exerciseName: 'Bench Press',
+            sets: [
+              const SetLog(setNumber: 1, plannedReps: 10, weight: 80, actualReps: 10, completed: true),
+            ],
+          ),
+          ExerciseLog(
+            exerciseId: 'ex2',
+            exerciseName: 'Rows',
+            skipped: true,
+            sets: [
+              const SetLog(setNumber: 1, plannedReps: 10, weight: 60, actualReps: 10, completed: true),
+            ],
+          ),
+        ],
+      );
+      expect(session.totalVolume, 800); // Only bench press
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Complete workout tracker with inline Strong-style set input (weight/reps/check)
- Domain models: Exercise, ExerciseLog, SetLog, WorkoutSession, WorkoutPlan with full JSON serialization
- ActiveSessionNotifier managing full session lifecycle (start, log, skip, add/remove sets, complete)
- 3 exercise types: weighted (kg+reps), timed (seconds), bodyweight (reps only)
- RestTimerService with timestamp-based timer (survives app backgrounding) + animated progress ring overlay
- WorkoutRepository with offline-first Hive storage and API sync support
- Live modifications: add/remove sets, add custom exercises, skip/unskip exercises during workout

## Test plan
- [x] 31 new unit tests for domain models, rest timer, and session logic (67 total)
- [x] `flutter analyze` -- zero warnings
- [ ] Manual: start workout, log sets, check rest timer, complete workout
- [ ] Manual: verify offline persistence (kill app, reopen)

Closes #12