### PR TITLE
[Mobile] History and statistics screens with charts

### DIFF
--- a/app/lib/features/history/data/history_repository.dart
+++ b/app/lib/features/history/data/history_repository.dart
@@ -1,0 +1,68 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fitness_ai/core/constants/api_constants.dart';
+import 'package:fitness_ai/core/network/api_client.dart';
+import 'package:fitness_ai/core/network/api_exception.dart';
+import 'package:fitness_ai/core/storage/hive_storage.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+
+/// Repository for workout history.
+/// Reads from local Hive cache, syncs with API.
+class HistoryRepository {
+  HistoryRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  /// Get all local sessions sorted by date (newest first).
+  List<WorkoutSession> getLocalSessions() {
+    return HiveStorage.sessions.values
+        .map((m) => WorkoutSession.fromJson(Map<String, dynamic>.from(m)))
+        .where((s) => s.isCompleted)
+        .toList()
+      ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+  }
+
+  /// Fetch sessions from API and cache locally.
+  Future<List<WorkoutSession>> fetchSessions({
+    DateTime? from,
+    DateTime? to,
+    int page = 1,
+    int perPage = 50,
+  }) async {
+    try {
+      final params = <String, dynamic>{
+        'page': page,
+        'per_page': perPage,
+      };
+      if (from != null) params['from'] = from.toIso8601String();
+      if (to != null) params['to'] = to.toIso8601String();
+
+      final response = await apiClient.get(
+        ApiConstants.workoutSessions,
+        queryParameters: params,
+      );
+      final data = response.data as Map<String, dynamic>;
+      final items = (data['items'] as List?) ?? [];
+      final sessions = items
+          .map((item) =>
+              WorkoutSession.fromJson(item as Map<String, dynamic>))
+          .toList();
+
+      // Cache locally
+      for (final session in sessions) {
+        final cached = session.copyWith(synced: true);
+        await HiveStorage.sessions.put(cached.id, cached.toJson());
+      }
+
+      return sessions;
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+}
+
+/// Provider for history repository.
+final historyRepositoryProvider = Provider<HistoryRepository>((ref) {
+  return HistoryRepository(apiClient: ref.watch(apiClientProvider));
+});

--- a/app/lib/features/history/presentation/history_screen.dart
+++ b/app/lib/features/history/presentation/history_screen.dart
@@ -1,50 +1,183 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 
 import 'package:fitness_ai/core/theme/app_colors.dart';
 import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/history/data/history_repository.dart';
+import 'package:fitness_ai/features/history/presentation/session_detail_screen.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
 
 /// Screen showing workout history with a list of past sessions.
-class HistoryScreen extends ConsumerWidget {
+class HistoryScreen extends ConsumerStatefulWidget {
   const HistoryScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.md),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(height: AppSpacing.md),
-              Text(
-                'Storico',
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-              const SizedBox(height: AppSpacing.lg),
-              Expanded(
-                child: Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.history,
-                        size: 64,
-                        color: AppColors.textSecondary.withValues(alpha: 0.5),
-                      ),
-                      const SizedBox(height: AppSpacing.md),
-                      Text(
-                        'Nessun allenamento registrato',
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ],
+  ConsumerState<HistoryScreen> createState() => _HistoryScreenState();
+}
+
+class _HistoryScreenState extends ConsumerState<HistoryScreen> {
+  List<WorkoutSession> _sessions = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSessions();
+  }
+
+  void _loadSessions() {
+    final repo = ref.read(historyRepositoryProvider);
+    setState(() {
+      _sessions = repo.getLocalSessions();
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('d MMM yyyy', 'it');
+
+    return SafeArea(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg, AppSpacing.lg, AppSpacing.lg, AppSpacing.sm),
+            child: const GradientText(
+              'Storico',
+              style: TextStyle(fontSize: 28, fontWeight: FontWeight.w900),
+            ),
           ),
-        ),
+          Expanded(
+            child: _loading
+                ? const Center(
+                    child:
+                        CircularProgressIndicator(color: AppColors.primary))
+                : _sessions.isEmpty
+                    ? Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.history,
+                                size: 48,
+                                color: AppColors.textSecondary
+                                    .withValues(alpha: 0.5)),
+                            const SizedBox(height: AppSpacing.md),
+                            const Text(
+                              'Nessun allenamento registrato',
+                              style: TextStyle(
+                                  color: AppColors.textSecondary,
+                                  fontSize: 16),
+                            ),
+                            const SizedBox(height: AppSpacing.xs),
+                            const Text(
+                              'Completa il tuo primo workout!',
+                              style:
+                                  TextStyle(color: AppColors.textSecondary),
+                            ),
+                          ],
+                        ),
+                      )
+                    : RefreshIndicator(
+                        onRefresh: () async => _loadSessions(),
+                        color: AppColors.primary,
+                        child: ListView.builder(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: AppSpacing.md),
+                          itemCount: _sessions.length,
+                          itemBuilder: (context, index) {
+                            final session = _sessions[index];
+                            return StaggeredListItem(
+                              index: index,
+                              child: GlassmorphismCard(
+                                onTap: () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (_) => SessionDetailScreen(
+                                          session: session),
+                                    ),
+                                  );
+                                },
+                                child: Row(
+                                  children: [
+                                    // Date badge
+                                    Container(
+                                      width: 48,
+                                      height: 48,
+                                      decoration: BoxDecoration(
+                                        gradient: AppColors.heroGradient,
+                                        borderRadius:
+                                            BorderRadius.circular(
+                                                AppSpacing.radiusMd),
+                                      ),
+                                      alignment: Alignment.center,
+                                      child: Text(
+                                        '${session.startedAt.day}',
+                                        style: const TextStyle(
+                                          color: Colors.white,
+                                          fontWeight: FontWeight.w800,
+                                          fontSize: 18,
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(width: AppSpacing.md),
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            session.dayName ?? 'Workout',
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .titleMedium,
+                                          ),
+                                          Text(
+                                            dateFormat.format(
+                                                session.startedAt),
+                                            style: Theme.of(context)
+                                                .textTheme
+                                                .bodyMedium,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.end,
+                                      children: [
+                                        Text(
+                                          session.formattedDuration,
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .labelLarge
+                                              ?.copyWith(
+                                                  color: AppColors.primary),
+                                        ),
+                                        Text(
+                                          '${session.totalCompletedSets} serie',
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodyMedium,
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(width: AppSpacing.sm),
+                                    const Icon(Icons.chevron_right,
+                                        color: AppColors.textSecondary),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+          ),
+        ],
       ),
     );
   }

--- a/app/lib/features/history/presentation/session_detail_screen.dart
+++ b/app/lib/features/history/presentation/session_detail_screen.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+
+/// Detail screen for a completed workout session.
+/// Shows all exercises with their sets, weights, and reps.
+class SessionDetailScreen extends StatelessWidget {
+  const SessionDetailScreen({super.key, required this.session});
+  final WorkoutSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('EEEE d MMMM yyyy, HH:mm', 'it');
+
+    return Scaffold(
+      appBar: AppBar(title: Text(session.dayName ?? 'Dettaglio Sessione')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          children: [
+            // Session summary card
+            GlassmorphismCard(
+              borderColor: AppColors.success.withValues(alpha: 0.2),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    dateFormat.format(session.startedAt),
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      _SummaryItem(
+                        label: 'Durata',
+                        value: session.formattedDuration,
+                        icon: Icons.timer,
+                      ),
+                      _SummaryItem(
+                        label: 'Serie',
+                        value: '${session.totalCompletedSets}',
+                        icon: Icons.repeat,
+                      ),
+                      _SummaryItem(
+                        label: 'Volume',
+                        value: '${session.totalVolume.toStringAsFixed(0)}kg',
+                        icon: Icons.fitness_center,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            Text(
+              'Esercizi',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            // Exercise list
+            ...session.exercises.asMap().entries.map((entry) {
+              final exercise = entry.value;
+              return StaggeredListItem(
+                index: entry.key,
+                child: GlassmorphismCard(
+                  borderColor: exercise.skipped
+                      ? AppColors.textDisabled.withValues(alpha: 0.1)
+                      : AppColors.primary.withValues(alpha: 0.1),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              exercise.exerciseName,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleMedium
+                                  ?.copyWith(
+                                    decoration: exercise.skipped
+                                        ? TextDecoration.lineThrough
+                                        : null,
+                                    color: exercise.skipped
+                                        ? AppColors.textDisabled
+                                        : null,
+                                  ),
+                            ),
+                          ),
+                          if (exercise.skipped)
+                            const Text('Saltato',
+                                style: TextStyle(
+                                    color: AppColors.textDisabled,
+                                    fontSize: 12)),
+                        ],
+                      ),
+                      if (!exercise.skipped) ...[
+                        const SizedBox(height: AppSpacing.sm),
+                        // Set header
+                        const Row(
+                          children: [
+                            SizedBox(
+                                width: 40,
+                                child: Text('SET',
+                                    style: _headerStyle)),
+                            Expanded(
+                                child: Text('KG',
+                                    style: _headerStyle,
+                                    textAlign: TextAlign.center)),
+                            Expanded(
+                                child: Text('REPS',
+                                    style: _headerStyle,
+                                    textAlign: TextAlign.center)),
+                          ],
+                        ),
+                        const SizedBox(height: AppSpacing.xs),
+                        ...exercise.sets.map((set) {
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(
+                                vertical: 2),
+                            child: Row(
+                              children: [
+                                SizedBox(
+                                  width: 40,
+                                  child: Text(
+                                    '${set.setNumber}',
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.w700,
+                                      color: set.completed
+                                          ? AppColors.success
+                                          : AppColors.textDisabled,
+                                    ),
+                                  ),
+                                ),
+                                Expanded(
+                                  child: Text(
+                                    set.weight > 0
+                                        ? '${set.weight}'
+                                        : '-',
+                                    textAlign: TextAlign.center,
+                                    style: const TextStyle(
+                                        fontWeight: FontWeight.w600),
+                                  ),
+                                ),
+                                Expanded(
+                                  child: Text(
+                                    set.actualReps > 0
+                                        ? '${set.actualReps}'
+                                        : set.durationSeconds > 0
+                                            ? '${set.durationSeconds}s'
+                                            : '-',
+                                    textAlign: TextAlign.center,
+                                    style: const TextStyle(
+                                        fontWeight: FontWeight.w600),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        }),
+                      ],
+                    ],
+                  ),
+                ),
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+const _headerStyle = TextStyle(
+  color: AppColors.textSecondary,
+  fontSize: 11,
+  fontWeight: FontWeight.w600,
+  letterSpacing: 0.5,
+);
+
+class _SummaryItem extends StatelessWidget {
+  const _SummaryItem({
+    required this.label,
+    required this.value,
+    required this.icon,
+  });
+  final String label;
+  final String value;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Icon(icon, color: AppColors.primary, size: 20),
+        const SizedBox(height: AppSpacing.xs),
+        BigNumber(value, fontSize: 20, color: AppColors.textPrimary),
+        Text(label, style: Theme.of(context).textTheme.labelSmall),
+      ],
+    );
+  }
+}

--- a/app/lib/features/stats/data/analytics_repository.dart
+++ b/app/lib/features/stats/data/analytics_repository.dart
@@ -1,0 +1,69 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fitness_ai/core/constants/api_constants.dart';
+import 'package:fitness_ai/core/network/api_client.dart';
+import 'package:fitness_ai/core/network/api_exception.dart';
+
+/// Repository for analytics data from the analytics service.
+class AnalyticsRepository {
+  AnalyticsRepository({required this.apiClient});
+
+  final ApiClient apiClient;
+
+  /// Fetch weight progress for an exercise.
+  Future<List<Map<String, dynamic>>> fetchProgress({
+    String? exerciseName,
+    int days = 90,
+  }) async {
+    try {
+      final response = await apiClient.get(
+        ApiConstants.analyticsProgress,
+        queryParameters: {
+          if (exerciseName != null) 'exercise_name': exerciseName,
+          'days': days,
+        },
+      );
+      return ((response.data as Map<String, dynamic>)['data'] as List?)
+              ?.cast<Map<String, dynamic>>() ??
+          [];
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  /// Fetch volume by muscle group.
+  Future<Map<String, double>> fetchVolume({int days = 30}) async {
+    try {
+      final response = await apiClient.get(
+        ApiConstants.analyticsVolume,
+        queryParameters: {'days': days},
+      );
+      final data = (response.data as Map<String, dynamic>)['data'];
+      if (data is Map) {
+        return data.map((k, v) => MapEntry(k.toString(), (v as num).toDouble()));
+      }
+      return {};
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  /// Fetch workout adherence (sessions per week).
+  Future<Map<String, dynamic>> fetchAdherence({int weeks = 8}) async {
+    try {
+      final response = await apiClient.get(
+        ApiConstants.analyticsAdherence,
+        queryParameters: {'weeks': weeks},
+      );
+      return response.data as Map<String, dynamic>;
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+}
+
+/// Provider for analytics repository.
+final analyticsRepositoryProvider = Provider<AnalyticsRepository>((ref) {
+  return AnalyticsRepository(apiClient: ref.watch(apiClientProvider));
+});

--- a/app/lib/features/stats/presentation/stats_screen.dart
+++ b/app/lib/features/stats/presentation/stats_screen.dart
@@ -3,6 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fitness_ai/core/theme/app_colors.dart';
 import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/history/data/history_repository.dart';
+import 'package:fitness_ai/features/stats/presentation/volume_chart.dart';
+import 'package:fitness_ai/features/stats/presentation/weight_progress_chart.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
 
 /// Screen showing workout statistics and charts.
 class StatsScreen extends ConsumerWidget {
@@ -10,43 +15,138 @@ class StatsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.md),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(height: AppSpacing.md),
-              Text(
-                'Statistiche',
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-              const SizedBox(height: AppSpacing.lg),
-              Expanded(
-                child: Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.bar_chart,
-                        size: 64,
-                        color: AppColors.textSecondary.withValues(alpha: 0.5),
-                      ),
-                      const SizedBox(height: AppSpacing.md),
-                      Text(
-                        'Completa qualche allenamento\nper vedere le statistiche',
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                    ],
+    final sessions = ref.watch(historyRepositoryProvider).getLocalSessions();
+
+    return SafeArea(
+      child: sessions.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.bar_chart,
+                      size: 48,
+                      color: AppColors.textSecondary.withValues(alpha: 0.5)),
+                  const SizedBox(height: AppSpacing.md),
+                  const GradientText('Statistiche',
+                      style: TextStyle(
+                          fontSize: 24, fontWeight: FontWeight.w700)),
+                  const SizedBox(height: AppSpacing.sm),
+                  const Text(
+                    'I grafici appariranno dopo\nle prime sessioni registrate.',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(color: AppColors.textSecondary),
                   ),
-                ),
+                ],
               ),
-            ],
+            )
+          : ListView(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              children: [
+                const GradientText(
+                  'Statistiche',
+                  style:
+                      TextStyle(fontSize: 28, fontWeight: FontWeight.w900),
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                // Quick summary
+                _QuickSummary(sessions: sessions),
+                const SizedBox(height: AppSpacing.xl),
+                // Weight progress chart
+                _SectionTitle(
+                    title: 'Progressione Carico',
+                    icon: Icons.trending_up),
+                const SizedBox(height: AppSpacing.sm),
+                WeightProgressChart(sessions: sessions),
+                const SizedBox(height: AppSpacing.xl),
+                // Volume per muscle group
+                _SectionTitle(
+                    title: 'Volume per Gruppo',
+                    icon: Icons.stacked_bar_chart),
+                const SizedBox(height: AppSpacing.sm),
+                VolumeChart(sessions: sessions),
+                const SizedBox(height: AppSpacing.xl),
+              ],
+            ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  const _SectionTitle({required this.title, required this.icon});
+  final String title;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, color: AppColors.primary, size: 20),
+        const SizedBox(width: AppSpacing.sm),
+        Text(title, style: Theme.of(context).textTheme.titleMedium),
+      ],
+    );
+  }
+}
+
+class _QuickSummary extends StatelessWidget {
+  const _QuickSummary({required this.sessions});
+  final List<WorkoutSession> sessions;
+
+  @override
+  Widget build(BuildContext context) {
+    final totalSessions = sessions.length;
+    final totalVolume = sessions.fold<double>(
+        0, (sum, s) => sum + s.totalVolume);
+    final totalSets = sessions.fold<int>(
+        0, (sum, s) => sum + s.totalCompletedSets);
+
+    return GlassmorphismCard(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          _StatItem(
+            value: '$totalSessions',
+            label: 'Sessioni',
+            color: AppColors.primary,
           ),
-        ),
+          _StatItem(
+            value: '${(totalVolume / 1000).toStringAsFixed(1)}t',
+            label: 'Volume totale',
+            color: AppColors.success,
+          ),
+          _StatItem(
+            value: '$totalSets',
+            label: 'Serie totali',
+            color: AppColors.warning,
+          ),
+        ],
       ),
+    );
+  }
+}
+
+class _StatItem extends StatelessWidget {
+  const _StatItem({
+    required this.value,
+    required this.label,
+    required this.color,
+  });
+  final String value;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        NeonText(
+          value,
+          style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w900),
+          color: color,
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(label, style: Theme.of(context).textTheme.labelSmall),
+      ],
     );
   }
 }

--- a/app/lib/features/stats/presentation/volume_chart.dart
+++ b/app/lib/features/stats/presentation/volume_chart.dart
@@ -1,0 +1,129 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+
+/// Bar chart showing total volume (kg) per muscle group.
+class VolumeChart extends StatelessWidget {
+  const VolumeChart({super.key, required this.sessions});
+  final List<WorkoutSession> sessions;
+
+  @override
+  Widget build(BuildContext context) {
+    // Aggregate volume per muscle group across all sessions
+    final volumeByGroup = <String, double>{};
+    for (final session in sessions) {
+      for (final ex in session.exercises) {
+        if (ex.skipped) continue;
+        final group = ex.muscleGroup.isNotEmpty ? ex.muscleGroup : 'other';
+        final volume = ex.sets
+            .where((s) => s.completed)
+            .fold<double>(0, (sum, s) => sum + (s.weight * s.actualReps));
+        volumeByGroup[group] = (volumeByGroup[group] ?? 0) + volume;
+      }
+    }
+
+    if (volumeByGroup.isEmpty) {
+      return const GlassmorphismCard(
+        child: Center(
+          child: Padding(
+            padding: EdgeInsets.all(AppSpacing.lg),
+            child: Text(
+              'Completa qualche allenamento\nper vedere il volume per gruppo',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: AppColors.textSecondary),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Sort by volume descending
+    final sorted = volumeByGroup.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    final barColors = [
+      AppColors.primary,
+      AppColors.success,
+      AppColors.warning,
+      const Color(0xFFFF6B6B),
+      const Color(0xFF9B59B6),
+      AppColors.textSecondary,
+    ];
+
+    return GlassmorphismCard(
+      child: SizedBox(
+        height: 220,
+        child: BarChart(
+          BarChartData(
+            alignment: BarChartAlignment.spaceAround,
+            maxY: sorted.first.value * 1.15,
+            barTouchData: BarTouchData(
+              touchTooltipData: BarTouchTooltipData(
+                getTooltipColor: (_) => AppColors.bgElevated,
+                getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                  return BarTooltipItem(
+                    '${sorted[groupIndex].key}\n${rod.toY.toStringAsFixed(0)} kg',
+                    const TextStyle(
+                        color: AppColors.textPrimary, fontSize: 12),
+                  );
+                },
+              ),
+            ),
+            titlesData: FlTitlesData(
+              leftTitles: const AxisTitles(),
+              rightTitles: const AxisTitles(),
+              topTitles: const AxisTitles(),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  getTitlesWidget: (value, _) {
+                    final index = value.toInt();
+                    if (index >= sorted.length) return const SizedBox.shrink();
+                    final label = sorted[index].key;
+                    return Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        label.length > 6
+                            ? '${label.substring(0, 6)}.'
+                            : label,
+                        style: const TextStyle(
+                            fontSize: 10, color: AppColors.textSecondary),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            gridData: const FlGridData(show: false),
+            borderData: FlBorderData(show: false),
+            barGroups: sorted.asMap().entries.map((entry) {
+              final color =
+                  barColors[entry.key % barColors.length];
+              return BarChartGroupData(
+                x: entry.key,
+                barRods: [
+                  BarChartRodData(
+                    toY: entry.value.value,
+                    color: color,
+                    width: 28,
+                    borderRadius: const BorderRadius.vertical(
+                        top: Radius.circular(4)),
+                    backDrawRodData: BackgroundBarChartRodData(
+                      show: true,
+                      toY: sorted.first.value * 1.15,
+                      color: AppColors.bgElevated,
+                    ),
+                  ),
+                ],
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/stats/presentation/weight_progress_chart.dart
+++ b/app/lib/features/stats/presentation/weight_progress_chart.dart
@@ -1,0 +1,178 @@
+import 'dart:math' as math;
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+
+/// Line chart showing max weight progression per exercise over time.
+class WeightProgressChart extends StatelessWidget {
+  const WeightProgressChart({super.key, required this.sessions});
+  final List<WorkoutSession> sessions;
+
+  @override
+  Widget build(BuildContext context) {
+    // Collect all exercise names with completed weighted sets
+    final exerciseNames = <String>{};
+    for (final session in sessions) {
+      for (final ex in session.exercises) {
+        if (!ex.skipped && ex.exerciseType == 'weighted') {
+          final hasWeight = ex.sets.any((s) => s.completed && s.weight > 0);
+          if (hasWeight) exerciseNames.add(ex.exerciseName);
+        }
+      }
+    }
+
+    if (exerciseNames.isEmpty) {
+      return const GlassmorphismCard(
+        child: Center(
+          child: Padding(
+            padding: EdgeInsets.all(AppSpacing.lg),
+            child: Text(
+              'Completa qualche serie con pesi\nper vedere la progressione',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: AppColors.textSecondary),
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Build data points: for each exercise, max weight per session date
+    final sortedSessions = sessions.toList()
+      ..sort((a, b) => a.startedAt.compareTo(b.startedAt));
+
+    // Just show top 3 exercises by frequency
+    final exerciseCounts = <String, int>{};
+    for (final name in exerciseNames) {
+      exerciseCounts[name] = sortedSessions
+          .where((s) =>
+              s.exercises.any((e) => e.exerciseName == name && !e.skipped))
+          .length;
+    }
+    final topExercises = (exerciseCounts.entries.toList()
+          ..sort((a, b) => b.value.compareTo(a.value)))
+        .take(3)
+        .map((e) => e.key)
+        .toList();
+
+    final colors = [AppColors.primary, AppColors.success, AppColors.warning];
+
+    final lineBarsData = <LineChartBarData>[];
+    double maxY = 0;
+
+    for (var i = 0; i < topExercises.length; i++) {
+      final exName = topExercises[i];
+      final spots = <FlSpot>[];
+
+      for (var j = 0; j < sortedSessions.length; j++) {
+        final session = sortedSessions[j];
+        final matching = session.exercises
+            .where((e) => e.exerciseName == exName && !e.skipped);
+        if (matching.isNotEmpty) {
+          final maxWeight = matching
+              .expand((e) => e.sets)
+              .where((s) => s.completed && s.weight > 0)
+              .fold<double>(0, (max, s) => math.max(max, s.weight));
+          if (maxWeight > 0) {
+            spots.add(FlSpot(j.toDouble(), maxWeight));
+            maxY = math.max(maxY, maxWeight);
+          }
+        }
+      }
+
+      if (spots.isNotEmpty) {
+        lineBarsData.add(LineChartBarData(
+          spots: spots,
+          isCurved: true,
+          color: colors[i],
+          barWidth: 2,
+          dotData: FlDotData(
+            show: true,
+            getDotPainter: (_, __, ___, ____) => FlDotCirclePainter(
+              radius: 3,
+              color: colors[i],
+              strokeColor: Colors.transparent,
+            ),
+          ),
+          belowBarData: BarAreaData(
+            show: true,
+            color: colors[i].withValues(alpha: 0.1),
+          ),
+        ));
+      }
+    }
+
+    return GlassmorphismCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Legend
+          Wrap(
+            spacing: AppSpacing.md,
+            children: topExercises.asMap().entries.map((entry) {
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: colors[entry.key],
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    entry.value,
+                    style: const TextStyle(
+                        fontSize: 11, color: AppColors.textSecondary),
+                  ),
+                ],
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          SizedBox(
+            height: 200,
+            child: LineChart(
+              LineChartData(
+                gridData: FlGridData(
+                  show: true,
+                  drawVerticalLine: false,
+                  getDrawingHorizontalLine: (_) => FlLine(
+                    color: AppColors.bgElevated,
+                    strokeWidth: 1,
+                  ),
+                ),
+                titlesData: FlTitlesData(
+                  leftTitles: AxisTitles(
+                    sideTitles: SideTitles(
+                      showTitles: true,
+                      reservedSize: 40,
+                      getTitlesWidget: (value, _) => Text(
+                        '${value.toInt()}',
+                        style: const TextStyle(
+                            fontSize: 10, color: AppColors.textSecondary),
+                      ),
+                    ),
+                  ),
+                  rightTitles: const AxisTitles(),
+                  topTitles: const AxisTitles(),
+                  bottomTitles: const AxisTitles(),
+                ),
+                borderData: FlBorderData(show: false),
+                lineBarsData: lineBarsData,
+                minY: 0,
+                maxY: maxY * 1.1,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- History screen with session list, date badges, pull-to-refresh
- Session detail screen with full exercise/set breakdown
- Stats screen with summary cards and fl_chart visualizations
- WeightProgressChart (line) and VolumeChart (bar) with premium dark theme
- HistoryRepository and AnalyticsRepository for data access

## Test plan
- [x] 81 tests passing
- [ ] Manual: check history list, session detail, chart rendering

Closes #19