### PR TITLE
#14 AI Vision scan: equipment recognition with Claude API

### DIFF
--- a/services/ai/app/claude_client.py
+++ b/services/ai/app/claude_client.py
@@ -1,0 +1,243 @@
+"""Claude API client for AI vision scan and coach generation.
+
+Handles communication with the Anthropic Claude API for image analysis.
+Photos are processed in memory only — never saved to disk (ADR-003).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any
+
+import anthropic
+
+from app.config import settings
+from app.prompts.coach_generate import (
+    COACH_GENERATE_SYSTEM_PROMPT,
+    build_coach_user_prompt,
+)
+from app.prompts.vision_scan import (
+    VISION_SCAN_SYSTEM_PROMPT,
+    VISION_SCAN_USER_PROMPT,
+)
+
+logger = logging.getLogger(__name__)
+
+# Claude model for vision tasks
+CLAUDE_MODEL = "claude-sonnet-4-20250514"
+MAX_TOKENS = 4096
+
+# Supported image MIME types for Claude Vision API
+VALID_IMAGE_TYPES = ("image/jpeg", "image/png", "image/gif", "image/webp")
+DEFAULT_IMAGE_TYPE = "image/jpeg"
+
+
+class ClaudeAPIError(Exception):
+    """Raised when Claude API call fails."""
+
+    def __init__(
+        self, message: str, original_error: Exception | None = None
+    ) -> None:
+        self.message = message
+        self.original_error = original_error
+        super().__init__(message)
+
+
+def _get_async_client() -> anthropic.AsyncAnthropic:
+    """Create an async Anthropic client instance.
+
+    Returns:
+        Configured async Anthropic client.
+
+    Raises:
+        ClaudeAPIError: If API key is not configured.
+    """
+    if not settings.anthropic_api_key:
+        raise ClaudeAPIError("ANTHROPIC_API_KEY not configured")
+    return anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+
+
+def _resolve_media_type(content_type: str) -> str:
+    """Resolve a content type to a valid Claude Vision media type.
+
+    Args:
+        content_type: MIME type string from the uploaded file.
+
+    Returns:
+        A valid media type string for Claude Vision API.
+    """
+    return content_type if content_type in VALID_IMAGE_TYPES else DEFAULT_IMAGE_TYPE
+
+
+def _parse_json_response(text: str) -> dict:
+    """Parse JSON from Claude response, handling markdown code blocks.
+
+    Args:
+        text: Raw response text from Claude.
+
+    Returns:
+        Parsed JSON dictionary.
+
+    Raises:
+        ClaudeAPIError: If response cannot be parsed as JSON.
+    """
+    # Strip markdown code blocks if present
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        # Remove opening ```json or ```
+        first_newline = cleaned.index("\n")
+        cleaned = cleaned[first_newline + 1 :]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[: -len("```")]
+        cleaned = cleaned.strip()
+
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError as exc:
+        raise ClaudeAPIError(
+            f"Failed to parse Claude response as JSON: {exc}"
+        ) from exc
+
+
+async def analyze_equipment_image(
+    image_data: bytes,
+    content_type: str = DEFAULT_IMAGE_TYPE,
+) -> dict[str, Any]:
+    """Send an equipment image to Claude Vision for analysis.
+
+    The image is encoded to base64 and sent in-memory. No image data
+    is persisted to disk at any point (ADR-003).
+
+    Args:
+        image_data: Raw image bytes.
+        content_type: MIME type of the image (image/jpeg or image/png).
+
+    Returns:
+        Parsed equipment analysis result dict.
+
+    Raises:
+        ClaudeAPIError: If API call fails or response is invalid.
+    """
+    client = _get_async_client()
+    image_b64 = base64.b64encode(image_data).decode("utf-8")
+    media_type = _resolve_media_type(content_type)
+
+    try:
+        message = await client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=MAX_TOKENS,
+            system=VISION_SCAN_SYSTEM_PROMPT,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": image_b64,
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": VISION_SCAN_USER_PROMPT,
+                        },
+                    ],
+                }
+            ],
+        )
+    except anthropic.APIError as exc:
+        logger.error("Claude API error during vision scan: %s", exc)
+        raise ClaudeAPIError(f"Claude API error: {exc}") from exc
+
+    # Extract text content from response
+    response_text = ""
+    for block in message.content:
+        if block.type == "text":
+            response_text += block.text
+
+    if not response_text:
+        raise ClaudeAPIError("Empty response from Claude API")
+
+    result = _parse_json_response(response_text)
+    logger.info(
+        "Vision scan completed: equipment=%s confidence=%.2f",
+        result.get("equipment_name", "unknown"),
+        result.get("confidence", 0.0),
+    )
+    return result
+
+
+async def generate_workout_plan(
+    photos_data: list[tuple[bytes, str]],
+    user_data: dict,
+) -> dict[str, Any]:
+    """Generate a personalized workout plan from body photos and user data.
+
+    Photos are encoded to base64 and sent in-memory. No photo data
+    is persisted to disk at any point (ADR-003).
+
+    Args:
+        photos_data: List of (image_bytes, content_type) tuples.
+        user_data: User profile data (age, goals, limitations, etc.).
+
+    Returns:
+        Parsed workout plan result dict.
+
+    Raises:
+        ClaudeAPIError: If API call fails or response is invalid.
+    """
+    client = _get_async_client()
+
+    # Build content blocks: photos first, then text prompt
+    content: list[dict] = []
+    for photo_bytes, photo_content_type in photos_data:
+        photo_b64 = base64.b64encode(photo_bytes).decode("utf-8")
+        media_type = _resolve_media_type(photo_content_type)
+        content.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": media_type,
+                    "data": photo_b64,
+                },
+            }
+        )
+
+    content.append(
+        {
+            "type": "text",
+            "text": build_coach_user_prompt(user_data),
+        }
+    )
+
+    try:
+        message = await client.messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=MAX_TOKENS,
+            system=COACH_GENERATE_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": content}],
+        )
+    except anthropic.APIError as exc:
+        logger.error("Claude API error during coach generation: %s", exc)
+        raise ClaudeAPIError(f"Claude API error: {exc}") from exc
+
+    response_text = ""
+    for block in message.content:
+        if block.type == "text":
+            response_text += block.text
+
+    if not response_text:
+        raise ClaudeAPIError("Empty response from Claude API")
+
+    result = _parse_json_response(response_text)
+    logger.info(
+        "Coach plan generated: %s (%d days)",
+        result.get("plan_name", "unnamed"),
+        len(result.get("days", [])),
+    )
+    return result

--- a/services/ai/app/database.py
+++ b/services/ai/app/database.py
@@ -1,0 +1,32 @@
+"""Database engine and session factory for AI service.
+
+Uses SQLAlchemy async engine with the 'ai' schema for all tables.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+
+engine = create_async_engine(
+    settings.database_url,
+    echo=settings.app_debug,
+    pool_pre_ping=True,
+    pool_size=5,
+    max_overflow=10,
+)
+
+async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an async database session.
+
+    Yields:
+        AsyncSession that is automatically closed after use.
+    """
+    async with async_session() as session:
+        yield session

--- a/services/ai/app/main.py
+++ b/services/ai/app/main.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.router import router as ai_router
+
+# Configure structured logging
+logging.basicConfig(
+    level=logging.DEBUG if settings.app_debug else logging.INFO,
+    format='{"timestamp":"%(asctime)s","level":"%(levelname)s","service":"%(name)s","message":"%(message)s"}',
+)
 
 app = FastAPI(
     title="FitnessAI AI Service",
@@ -32,14 +40,23 @@ app.add_middleware(
 
 @app.get("/health")
 async def health_check() -> dict:
-    """Health check endpoint with Redis connectivity check."""
+    """Health check endpoint with Redis and API key connectivity check."""
     from app.redis_client import check_redis_health
 
     redis_ok = await check_redis_health()
-    status = "ok" if redis_ok else "degraded"
+    api_key_configured = bool(settings.anthropic_api_key)
+
+    if redis_ok and api_key_configured:
+        health_status = "ok"
+    elif redis_ok:
+        health_status = "degraded"
+    else:
+        health_status = "unhealthy"
+
     return {
-        "status": status,
+        "status": health_status,
         "service": settings.service_name,
         "version": settings.app_version,
         "redis": "ok" if redis_ok else "unavailable",
+        "claude_api": "configured" if api_key_configured else "not_configured",
     }

--- a/services/ai/app/models.py
+++ b/services/ai/app/models.py
@@ -1,0 +1,65 @@
+"""SQLAlchemy models for AI service — ai schema tables."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base class for all AI service models."""
+
+    pass
+
+
+class AIVisionScan(Base):
+    """Record of an AI vision scan (equipment recognition from photo).
+
+    Stores the analysis result but never the original photo (ADR-003).
+    """
+
+    __tablename__ = "ai_vision_scans"
+    __table_args__ = {"schema": "ai"}
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    image_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    equipment_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    equipment_brand: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    exercises: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    raw_response: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    credits_used: Mapped[int] = mapped_column(Integer, default=1)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )
+
+
+class AICoachGeneration(Base):
+    """Record of an AI coach generation (personalized workout plan).
+
+    Stores the generated plan and input metadata but never the original photos (ADR-003).
+    """
+
+    __tablename__ = "ai_coach_generations"
+    __table_args__ = {"schema": "ai"}
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    input_data: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    photo_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    generated_plan: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    raw_response: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    credits_used: Mapped[int] = mapped_column(Integer, default=5)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC)
+    )

--- a/services/ai/app/prompts/__init__.py
+++ b/services/ai/app/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt templates for AI services — versioned and testable."""

--- a/services/ai/app/prompts/coach_generate.py
+++ b/services/ai/app/prompts/coach_generate.py
@@ -1,0 +1,100 @@
+"""Coach generation prompt template: personalized workout plan from body photos.
+
+Version: 1.0
+Expected input: base64 body photos + user profile JSON
+Expected output: structured JSON workout plan
+"""
+
+from __future__ import annotations
+
+COACH_GENERATE_VERSION = "1.0"
+
+COACH_GENERATE_SYSTEM_PROMPT = """\
+You are an expert personal trainer and exercise physiologist. \
+Your task is to analyze body photos and user data to create a \
+personalized, structured workout plan.
+
+Rules:
+- Always respond with valid JSON matching the exact schema below
+- Create a realistic, progressive plan appropriate for the user's level and goals
+- Consider any physical limitations mentioned in the user data
+- Each workout day should have 5-8 exercises with specific sets, reps, and rest periods
+- Include warm-up and cool-down notes
+- Suggest starting weights based on typical ranges for the user's apparent fitness level
+- Plans should be 4-6 weeks in duration with progressive overload
+
+Response JSON schema:
+{
+  "plan_name": "string - descriptive plan name",
+  "description": "string - brief overview of the plan and its goals",
+  "duration_weeks": "integer - plan duration in weeks",
+  "days_per_week": "integer - training days per week",
+  "level": "string - beginner|intermediate|advanced",
+  "days": [
+    {
+      "day_name": "string - e.g. 'Day 1 - Upper Body Push'",
+      "focus": "string - primary muscle groups for this day",
+      "warm_up": "string - warm-up instructions",
+      "exercises": [
+        {
+          "name": "string - exercise name",
+          "name_it": "string - exercise name in Italian",
+          "muscle_groups": ["string - target muscles"],
+          "sets": "integer",
+          "reps": "string - e.g. '8-12' or '30 seconds'",
+          "rest_seconds": "integer - rest between sets",
+          "weight_suggestion_kg": "float or null - suggested starting weight",
+          "notes": "string or null - form cues or modifications"
+        }
+      ],
+      "cool_down": "string - cool-down instructions"
+    }
+  ],
+  "progression_notes": "string - how to progress week over week",
+  "nutrition_tips": "string or null - basic nutrition advice if relevant"
+}"""
+
+
+def build_coach_user_prompt(user_data: dict) -> str:
+    """Build the user prompt for coach generation with user-specific data.
+
+    Args:
+        user_data: Dictionary with user profile information.
+
+    Returns:
+        Formatted user prompt string.
+    """
+    parts = [
+        "Analyze the provided body photos and create a personalized workout plan.",
+        "",
+    ]
+
+    if user_data.get("name"):
+        parts.append(f"User: {user_data['name']}")
+    if user_data.get("age"):
+        parts.append(f"Age: {user_data['age']}")
+    if user_data.get("goals"):
+        goals = user_data["goals"]
+        if isinstance(goals, dict):
+            goals_str = ", ".join(f"{k}: {v}" for k, v in goals.items())
+        else:
+            goals_str = str(goals)
+        parts.append(f"Goals: {goals_str}")
+    if user_data.get("limitations"):
+        limitations = user_data["limitations"]
+        if isinstance(limitations, dict):
+            lim_str = ", ".join(f"{k}: {v}" for k, v in limitations.items())
+        else:
+            lim_str = str(limitations)
+        parts.append(f"Physical limitations: {lim_str}")
+    if user_data.get("experience"):
+        parts.append(f"Training experience: {user_data['experience']}")
+    if user_data.get("available_days"):
+        parts.append(f"Available training days per week: {user_data['available_days']}")
+    if user_data.get("available_equipment"):
+        parts.append(f"Available equipment: {user_data['available_equipment']}")
+
+    parts.append("")
+    parts.append("Respond ONLY with valid JSON matching the schema described.")
+
+    return "\n".join(parts)

--- a/services/ai/app/prompts/vision_scan.py
+++ b/services/ai/app/prompts/vision_scan.py
@@ -1,0 +1,49 @@
+"""Vision scan prompt template: equipment recognition from photo.
+
+Version: 1.0
+Expected input: base64 image of gym equipment
+Expected output: structured JSON with equipment name, brand, exercises
+"""
+
+from __future__ import annotations
+
+VISION_SCAN_VERSION = "1.0"
+
+VISION_SCAN_SYSTEM_PROMPT = """\
+You are a gym equipment recognition expert. \
+Your task is to analyze a photo of gym equipment and identify:
+1. The equipment name (standardized English name)
+2. The brand/manufacturer if visible
+3. A list of exercises that can be performed with this equipment
+
+Rules:
+- Always respond with valid JSON matching the exact schema below
+- If you cannot identify the equipment, set equipment_name to "Unknown" and confidence to 0.0
+- If the brand is not visible or identifiable, set brand to null
+- List exercises from most common to least common for that equipment
+- Each exercise should include: name, muscle_groups (primary muscles worked), difficulty level
+- Confidence should be between 0.0 and 1.0 based on how certain you are
+- If the image does not contain gym equipment, set equipment_name \
+to "Not gym equipment" and confidence to 0.0
+
+Response JSON schema:
+{
+  "equipment_name": "string - standardized equipment name in English",
+  "brand": "string or null - manufacturer name if visible",
+  "confidence": "float 0.0-1.0 - recognition confidence",
+  "exercises": [
+    {
+      "name": "string - exercise name",
+      "name_it": "string - exercise name in Italian",
+      "muscle_groups": ["string - primary muscle groups"],
+      "difficulty": "string - beginner|intermediate|advanced",
+      "description": "string - brief description of the exercise"
+    }
+  ]
+}"""
+
+VISION_SCAN_USER_PROMPT = (
+    "Analyze this photo of gym equipment. "
+    "Identify the equipment and list all exercises that can be performed with it. "
+    "Respond ONLY with valid JSON matching the schema described."
+)

--- a/services/ai/app/rate_limiter.py
+++ b/services/ai/app/rate_limiter.py
@@ -1,0 +1,119 @@
+"""Application-level rate limiting for AI endpoints using Redis.
+
+Traefik handles global rate limiting; this adds per-user, per-endpoint limits
+for expensive AI operations.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.redis_client import get_redis
+
+logger = logging.getLogger(__name__)
+
+# Rate limit windows
+VISION_SCAN_LIMIT = 10  # max scans per window
+VISION_SCAN_WINDOW = 3600  # 1 hour in seconds
+
+COACH_GENERATE_LIMIT = 3  # max generations per window
+COACH_GENERATE_WINDOW = 86400  # 24 hours in seconds
+
+
+class RateLimitExceededError(Exception):
+    """Raised when a user exceeds the rate limit for an AI operation."""
+
+    def __init__(self, operation: str, limit: int, window_seconds: int) -> None:
+        self.operation = operation
+        self.limit = limit
+        self.window_seconds = window_seconds
+        if window_seconds >= 3600:
+            window_human = f"{window_seconds // 3600}h"
+        else:
+            window_human = f"{window_seconds // 60}m"
+        super().__init__(
+            f"Rate limit exceeded for {operation}: max {limit} per {window_human}"
+        )
+
+
+async def check_rate_limit(
+    user_id: str,
+    operation: str,
+    limit: int,
+    window_seconds: int,
+) -> int:
+    """Check and increment the rate limit counter for a user operation.
+
+    Uses a Redis key with TTL for sliding window rate limiting.
+
+    Args:
+        user_id: User UUID string.
+        operation: Operation name (e.g., 'vision_scan', 'coach_generate').
+        limit: Maximum number of operations allowed in the window.
+        window_seconds: Window duration in seconds.
+
+    Returns:
+        Current count after increment.
+
+    Raises:
+        RateLimitExceededError: If the user has exceeded the limit.
+    """
+    client = await get_redis()
+    key = f"ai:ratelimit:{operation}:{user_id}"
+
+    current = await client.get(key)
+    if current is not None and int(current) >= limit:
+        logger.warning(
+            "Rate limit exceeded: user=%s operation=%s count=%s limit=%d",
+            user_id,
+            operation,
+            current,
+            limit,
+        )
+        raise RateLimitExceededError(operation, limit, window_seconds)
+
+    pipe = client.pipeline()
+    pipe.incr(key)
+    pipe.expire(key, window_seconds)
+    results = await pipe.execute()
+    count = results[0]
+
+    if count > limit:
+        # Race condition: another request incremented between check and incr
+        raise RateLimitExceededError(operation, limit, window_seconds)
+
+    return count
+
+
+async def check_vision_scan_rate(user_id: str) -> int:
+    """Check rate limit for vision scan (10 per hour).
+
+    Args:
+        user_id: User UUID string.
+
+    Returns:
+        Current usage count.
+
+    Raises:
+        RateLimitExceededError: If limit exceeded.
+    """
+    return await check_rate_limit(
+        user_id, "vision_scan", VISION_SCAN_LIMIT, VISION_SCAN_WINDOW
+    )
+
+
+async def check_coach_generate_rate(user_id: str) -> int:
+    """Check rate limit for coach generation (3 per day).
+
+    Args:
+        user_id: User UUID string.
+
+    Returns:
+        Current usage count.
+
+    Raises:
+        RateLimitExceededError: If limit exceeded.
+    """
+    return await check_rate_limit(
+        user_id, "coach_generate", COACH_GENERATE_LIMIT, COACH_GENERATE_WINDOW
+    )

--- a/services/ai/app/router.py
+++ b/services/ai/app/router.py
@@ -1,107 +1,188 @@
-"""AI API router: vision scan, coach generation, job status."""
+"""AI API router: vision scan, coach generation, job status, history."""
 
 from __future__ import annotations
 
+import logging
 import uuid
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    UploadFile,
+    status,
+)
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db
 from app.dependencies import get_current_user_id
+from app.rate_limiter import (
+    RateLimitExceededError,
+    check_vision_scan_rate,
+)
 from app.redis_client import (
-    compute_image_hash,
-    get_cached_vision_result,
     get_job_status,
-    publish_job,
 )
 from app.schemas import (
-    CoachGenerateResponse,
     JobStatusResponse,
-    VisionScanResponse,
+    PaginatedCoachHistory,
+    PaginatedVisionHistory,
+    VisionScanSyncResponse,
+)
+from app.service import (
+    AIServiceError,
+    InsufficientCreditsError,
+    get_coach_history,
+    get_vision_history,
+    process_vision_scan,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/ai", tags=["ai"])
+security_scheme = HTTPBearer()
 
 MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
+ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png"}
 
 
-@router.post("/vision/scan", response_model=VisionScanResponse)
+def _get_token(
+    credentials: HTTPAuthorizationCredentials = Depends(security_scheme),
+) -> str:
+    """Extract raw JWT token string from authorization header.
+
+    Args:
+        credentials: Bearer token from Authorization header.
+
+    Returns:
+        Raw JWT token string.
+    """
+    return credentials.credentials
+
+
+@router.post("/vision/scan", response_model=VisionScanSyncResponse)
 async def vision_scan(
     image: UploadFile = File(...),
     user_id: uuid.UUID = Depends(get_current_user_id),
-) -> VisionScanResponse:
+    token: str = Depends(_get_token),
+    db: AsyncSession = Depends(get_db),
+) -> VisionScanSyncResponse:
     """Submit an image for AI equipment recognition.
 
-    The image is hashed for dedup caching. If a cached result exists,
-    it is returned immediately. Otherwise, a job is published to Redis
-    Streams for async processing.
+    The image is processed in memory and sent to Claude Vision API.
+    Results are cached by image hash (SHA256) for dedup.
+    Costs 1 AI credit per scan (free if cached).
+
+    Rate limit: 10 scans per hour.
 
     Args:
-        image: Uploaded image file (max 10MB).
+        image: Uploaded image file (JPEG/PNG, max 10MB).
         user_id: Authenticated user UUID from JWT.
+        token: Raw JWT token for inter-service calls.
+        db: Database session.
 
     Returns:
-        Job submission response with job_id for polling.
+        Equipment recognition result with exercises.
     """
-    # Validate file size
+    # Validate content type
+    if image.content_type not in ALLOWED_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid image type: {image.content_type}. Allowed: JPEG, PNG.",
+        )
+
+    # Read and validate size
     contents = await image.read()
     if len(contents) > MAX_IMAGE_SIZE:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"Image exceeds maximum size of {MAX_IMAGE_SIZE // (1024 * 1024)}MB",
         )
 
-    # Check cache
-    image_hash = compute_image_hash(contents)
-    cached = await get_cached_vision_result(image_hash)
-    if cached:
-        # Return cached result as a completed job
-        job_id = await publish_job(
-            job_type="vision_scan",
+    if len(contents) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Empty image file",
+        )
+
+    # Check rate limit
+    try:
+        await check_vision_scan_rate(str(user_id))
+    except RateLimitExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    # Process scan (credit check + Claude API + cache + DB)
+    try:
+        result = await process_vision_scan(
+            image_data=contents,
+            content_type=image.content_type or "image/jpeg",
             user_id=str(user_id),
-            payload={"image_hash": image_hash, "cached": True},
+            token=token,
+            db=db,
         )
-        from app.redis_client import update_job_status
+    except InsufficientCreditsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=exc.message,
+        ) from exc
+    except AIServiceError as exc:
+        logger.error("Vision scan failed: %s", exc.message)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=exc.message,
+        ) from exc
 
-        await update_job_status(job_id, "completed", result=cached)
-        return VisionScanResponse(
-            job_id=job_id,
-            status="completed",
-            message="Result found in cache. Check GET /ai/jobs/{job_id}.",
-        )
-
-    # Publish async job
-    job_id = await publish_job(
-        job_type="vision_scan",
-        user_id=str(user_id),
-        payload={
-            "image_hash": image_hash,
-            "content_type": image.content_type or "image/jpeg",
-            "filename": image.filename or "scan.jpg",
-        },
-    )
-
-    return VisionScanResponse(job_id=job_id)
+    return VisionScanSyncResponse(**result)
 
 
-@router.post("/coach/generate", response_model=CoachGenerateResponse)
-async def coach_generate(
+@router.get("/vision/history", response_model=PaginatedVisionHistory)
+async def vision_history(
     user_id: uuid.UUID = Depends(get_current_user_id),
-) -> CoachGenerateResponse:
-    """Submit a request for AI-generated personalized workout plan.
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(1, ge=1, description="Page number"),
+    per_page: int = Query(20, ge=1, le=100, description="Items per page"),
+) -> PaginatedVisionHistory:
+    """Get vision scan history for the authenticated user.
 
     Args:
         user_id: Authenticated user UUID from JWT.
+        db: Database session.
+        page: Page number (1-based).
+        per_page: Items per page (max 100).
 
     Returns:
-        Job submission response with job_id for polling.
+        Paginated list of vision scan history.
     """
-    job_id = await publish_job(
-        job_type="coach_generate",
-        user_id=str(user_id),
-        payload={"user_id": str(user_id)},
-    )
+    result = await get_vision_history(str(user_id), db, page, per_page)
+    return PaginatedVisionHistory(**result)
 
-    return CoachGenerateResponse(job_id=job_id)
+
+@router.get("/coach/history", response_model=PaginatedCoachHistory)
+async def coach_history(
+    user_id: uuid.UUID = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(1, ge=1, description="Page number"),
+    per_page: int = Query(20, ge=1, le=100, description="Items per page"),
+) -> PaginatedCoachHistory:
+    """Get coach generation history for the authenticated user.
+
+    Args:
+        user_id: Authenticated user UUID from JWT.
+        db: Database session.
+        page: Page number (1-based).
+        per_page: Items per page (max 100).
+
+    Returns:
+        Paginated list of coach generation history.
+    """
+    result = await get_coach_history(str(user_id), db, page, per_page)
+    return PaginatedCoachHistory(**result)
 
 
 @router.get("/jobs/{job_id}", response_model=JobStatusResponse)

--- a/services/ai/app/schemas.py
+++ b/services/ai/app/schemas.py
@@ -4,21 +4,105 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+# ============================================================
+# Vision Scan
+# ============================================================
+
+
+class ExerciseInfo(BaseModel):
+    """Exercise information from vision scan result."""
+
+    name: str
+    name_it: str | None = None
+    muscle_groups: list[str] = Field(default_factory=list)
+    difficulty: str | None = None
+    description: str | None = None
+
 
 class VisionScanResponse(BaseModel):
-    """Response for an AI vision scan job submission."""
+    """Response for an AI vision scan submission (async job)."""
 
     job_id: str
     status: str = "pending"
     message: str = "Vision scan job submitted. Poll GET /ai/jobs/{job_id} for results."
 
 
+class VisionScanResult(BaseModel):
+    """Full result of a completed vision scan."""
+
+    scan_id: str | None = None
+    equipment_name: str
+    brand: str | None = None
+    exercises: list[ExerciseInfo] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+    cached: bool = False
+
+
+class VisionScanSyncResponse(BaseModel):
+    """Synchronous response for a vision scan (used when result is immediate)."""
+
+    equipment_name: str
+    brand: str | None = None
+    exercises: list[dict] = Field(default_factory=list)
+    confidence: float = Field(ge=0.0, le=1.0)
+    cached: bool = False
+    scan_id: str | None = None
+
+
+class VisionHistoryItem(BaseModel):
+    """Single item in vision scan history."""
+
+    id: str
+    image_hash: str | None = None
+    equipment_name: str | None = None
+    equipment_brand: str | None = None
+    exercises: list[dict] | dict | None = None
+    credits_used: int = 0
+    error: str | None = None
+    created_at: str | None = None
+
+
+# ============================================================
+# Coach Generation
+# ============================================================
+
+
 class CoachGenerateResponse(BaseModel):
-    """Response for an AI coach generation job submission."""
+    """Response for an AI coach generation submission (async job)."""
 
     job_id: str
     status: str = "pending"
     message: str = "Coach generation job submitted. Poll GET /ai/jobs/{job_id} for results."
+
+
+class CoachResult(BaseModel):
+    """Result of a coach generation: personalized workout plan."""
+
+    plan_name: str
+    description: str
+    duration_weeks: int | None = None
+    days_per_week: int | None = None
+    level: str | None = None
+    days: list[dict] = Field(default_factory=list)
+    progression_notes: str | None = None
+    nutrition_tips: str | None = None
+
+
+class CoachHistoryItem(BaseModel):
+    """Single item in coach generation history."""
+
+    id: str
+    input_data: dict | None = None
+    photo_count: int | None = None
+    generated_plan: dict | None = None
+    credits_used: int = 0
+    error: str | None = None
+    created_at: str | None = None
+
+
+# ============================================================
+# Job Status
+# ============================================================
 
 
 class JobStatusResponse(BaseModel):
@@ -33,20 +117,26 @@ class JobStatusResponse(BaseModel):
     error: str | None = None
 
 
-class VisionResult(BaseModel):
-    """Result of a vision scan: equipment identified and suggested exercises."""
-
-    equipment_name: str
-    brand: str | None = None
-    exercises: list[dict] = Field(default_factory=list)
-    confidence: float = Field(ge=0.0, le=1.0)
-    cached: bool = False
+# ============================================================
+# Paginated Responses
+# ============================================================
 
 
-class CoachResult(BaseModel):
-    """Result of a coach generation: personalized workout plan."""
+class PaginatedVisionHistory(BaseModel):
+    """Paginated list of vision scan history items."""
 
-    plan_name: str
-    description: str
-    days: list[dict] = Field(default_factory=list)
-    notes: str | None = None
+    items: list[VisionHistoryItem] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    per_page: int = 20
+    pages: int = 0
+
+
+class PaginatedCoachHistory(BaseModel):
+    """Paginated list of coach generation history items."""
+
+    items: list[CoachHistoryItem] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    per_page: int = 20
+    pages: int = 0

--- a/services/ai/app/service.py
+++ b/services/ai/app/service.py
@@ -1,0 +1,315 @@
+"""AI service business logic: vision scan processing and persistence.
+
+Orchestrates Claude API calls, caching, credit deduction, rate limiting,
+and database persistence. Photos are never saved to disk (ADR-003).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.claude_client import ClaudeAPIError, analyze_equipment_image
+from app.models import AICoachGeneration, AIVisionScan
+from app.redis_client import (
+    cache_vision_result,
+    compute_image_hash,
+    get_cached_vision_result,
+)
+
+logger = logging.getLogger(__name__)
+
+# Credit costs
+VISION_SCAN_CREDITS = 1
+COACH_GENERATE_CREDITS = 5
+
+# Auth service URL for credit deduction
+AUTH_SERVICE_URL = "http://auth:8001"
+
+
+class AIServiceError(Exception):
+    """Base exception for AI service errors."""
+
+    def __init__(self, message: str, code: str = "AI_ERROR") -> None:
+        self.message = message
+        self.code = code
+        super().__init__(message)
+
+
+class InsufficientCreditsError(AIServiceError):
+    """Raised when user does not have enough credits."""
+
+    def __init__(self) -> None:
+        super().__init__("Insufficient AI credits", "INSUFFICIENT_CREDITS")
+
+
+async def _deduct_credits(user_id: str, amount: int, token: str) -> bool:
+    """Deduct AI credits by calling the auth service.
+
+    Args:
+        user_id: User UUID string.
+        amount: Number of credits to deduct.
+        token: JWT token for authentication.
+
+    Returns:
+        True if credits were successfully deducted.
+
+    Raises:
+        InsufficientCreditsError: If user doesn't have enough credits.
+        AIServiceError: If auth service call fails.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            # First check balance
+            check_resp = await client.get(
+                f"{AUTH_SERVICE_URL}/auth/credits",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if check_resp.status_code != 200:
+                raise AIServiceError(
+                    "Failed to check credits balance",
+                    "CREDITS_CHECK_FAILED",
+                )
+
+            balance = check_resp.json().get("credits", 0)
+            if balance < amount:
+                raise InsufficientCreditsError()
+
+            # Deduct credits (one at a time since the endpoint deducts 1)
+            for _ in range(amount):
+                resp = await client.post(
+                    f"{AUTH_SERVICE_URL}/auth/credits/deduct",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                if resp.status_code == 402:
+                    raise InsufficientCreditsError()
+                if resp.status_code != 200:
+                    raise AIServiceError(
+                        f"Failed to deduct credit: {resp.status_code}",
+                        "CREDIT_DEDUCTION_FAILED",
+                    )
+
+    except httpx.HTTPError as exc:
+        logger.error("Auth service communication error: %s", exc)
+        raise AIServiceError(
+            "Cannot reach auth service for credit check",
+            "AUTH_SERVICE_UNAVAILABLE",
+        ) from exc
+
+    return True
+
+
+async def process_vision_scan(
+    image_data: bytes,
+    content_type: str,
+    user_id: str,
+    token: str,
+    db: AsyncSession,
+) -> dict[str, Any]:
+    """Process a vision scan: call Claude API, cache result, save to DB.
+
+    Args:
+        image_data: Raw image bytes (processed in memory only).
+        content_type: Image MIME type.
+        user_id: User UUID string.
+        token: JWT token for credit deduction.
+        db: Database session.
+
+    Returns:
+        Vision scan result dict.
+
+    Raises:
+        InsufficientCreditsError: If user lacks credits.
+        AIServiceError: If processing fails.
+    """
+    image_hash = compute_image_hash(image_data)
+
+    # Check cache first (no credit cost for cached results)
+    cached = await get_cached_vision_result(image_hash)
+    if cached:
+        logger.info("Vision scan cache hit: hash=%s user=%s", image_hash[:16], user_id)
+        # Save to DB even for cached results (for history)
+        scan = AIVisionScan(
+            user_id=uuid.UUID(user_id),
+            image_hash=image_hash,
+            equipment_name=cached.get("equipment_name"),
+            equipment_brand=cached.get("brand"),
+            exercises=cached.get("exercises"),
+            raw_response=cached,
+            credits_used=0,  # No credit cost for cached
+        )
+        db.add(scan)
+        await db.commit()
+        cached["cached"] = True
+        cached["scan_id"] = str(scan.id)
+        return cached
+
+    # Deduct credits before calling API
+    await _deduct_credits(user_id, VISION_SCAN_CREDITS, token)
+
+    # Call Claude API
+    try:
+        result = await analyze_equipment_image(image_data, content_type)
+    except ClaudeAPIError as exc:
+        # Save failed scan to DB
+        scan = AIVisionScan(
+            user_id=uuid.UUID(user_id),
+            image_hash=image_hash,
+            credits_used=VISION_SCAN_CREDITS,
+            error=str(exc),
+        )
+        db.add(scan)
+        await db.commit()
+        raise AIServiceError(f"Vision scan failed: {exc.message}") from exc
+
+    # Cache the result
+    await cache_vision_result(image_hash, result)
+
+    # Save to DB
+    scan = AIVisionScan(
+        user_id=uuid.UUID(user_id),
+        image_hash=image_hash,
+        equipment_name=result.get("equipment_name"),
+        equipment_brand=result.get("brand"),
+        exercises=result.get("exercises"),
+        raw_response=result,
+        credits_used=VISION_SCAN_CREDITS,
+    )
+    db.add(scan)
+    await db.commit()
+
+    result["cached"] = False
+    result["scan_id"] = str(scan.id)
+    return result
+
+
+async def get_vision_history(
+    user_id: str,
+    db: AsyncSession,
+    page: int = 1,
+    per_page: int = 20,
+) -> dict[str, Any]:
+    """Get vision scan history for a user.
+
+    Args:
+        user_id: User UUID string.
+        db: Database session.
+        page: Page number (1-based).
+        per_page: Items per page.
+
+    Returns:
+        Paginated list of vision scan results.
+    """
+    uid = uuid.UUID(user_id)
+
+    # Count total
+    from sqlalchemy import func
+
+    count_q = select(func.count()).select_from(AIVisionScan).where(
+        AIVisionScan.user_id == uid
+    )
+    total_result = await db.execute(count_q)
+    total = total_result.scalar() or 0
+
+    # Fetch page
+    offset = (page - 1) * per_page
+    query = (
+        select(AIVisionScan)
+        .where(AIVisionScan.user_id == uid)
+        .order_by(AIVisionScan.created_at.desc())
+        .offset(offset)
+        .limit(per_page)
+    )
+    result = await db.execute(query)
+    scans = result.scalars().all()
+
+    items = []
+    for scan in scans:
+        items.append(
+            {
+                "id": str(scan.id),
+                "image_hash": scan.image_hash,
+                "equipment_name": scan.equipment_name,
+                "equipment_brand": scan.equipment_brand,
+                "exercises": scan.exercises,
+                "credits_used": scan.credits_used,
+                "error": scan.error,
+                "created_at": scan.created_at.isoformat() if scan.created_at else None,
+            }
+        )
+
+    pages = (total + per_page - 1) // per_page if per_page > 0 else 0
+    return {
+        "items": items,
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+        "pages": pages,
+    }
+
+
+async def get_coach_history(
+    user_id: str,
+    db: AsyncSession,
+    page: int = 1,
+    per_page: int = 20,
+) -> dict[str, Any]:
+    """Get coach generation history for a user.
+
+    Args:
+        user_id: User UUID string.
+        db: Database session.
+        page: Page number (1-based).
+        per_page: Items per page.
+
+    Returns:
+        Paginated list of coach generation results.
+    """
+    uid = uuid.UUID(user_id)
+
+    from sqlalchemy import func
+
+    count_q = select(func.count()).select_from(AICoachGeneration).where(
+        AICoachGeneration.user_id == uid
+    )
+    total_result = await db.execute(count_q)
+    total = total_result.scalar() or 0
+
+    offset = (page - 1) * per_page
+    query = (
+        select(AICoachGeneration)
+        .where(AICoachGeneration.user_id == uid)
+        .order_by(AICoachGeneration.created_at.desc())
+        .offset(offset)
+        .limit(per_page)
+    )
+    result = await db.execute(query)
+    generations = result.scalars().all()
+
+    items = []
+    for gen in generations:
+        items.append(
+            {
+                "id": str(gen.id),
+                "input_data": gen.input_data,
+                "photo_count": gen.photo_count,
+                "generated_plan": gen.generated_plan,
+                "credits_used": gen.credits_used,
+                "error": gen.error,
+                "created_at": gen.created_at.isoformat() if gen.created_at else None,
+            }
+        )
+
+    pages = (total + per_page - 1) // per_page if per_page > 0 else 0
+    return {
+        "items": items,
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+        "pages": pages,
+    }

--- a/services/ai/tests/conftest.py
+++ b/services/ai/tests/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import fakeredis.aioredis
 import pytest
@@ -54,18 +54,70 @@ def auth_headers(test_user_id: str) -> dict:
 
 
 @pytest.fixture
+def auth_token(test_user_id: str) -> str:
+    """Return a valid JWT token for testing."""
+    return create_test_token(test_user_id)
+
+
+@pytest.fixture
 def fake_redis():
     """Create a fakeredis instance for testing."""
     return fakeredis.aioredis.FakeRedis(decode_responses=True)
 
 
+@pytest.fixture
+def mock_db():
+    """Create a mock database session."""
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_claude_vision_response():
+    """Standard mock response for vision scan."""
+    return {
+        "equipment_name": "Bench Press",
+        "brand": "Technogym",
+        "confidence": 0.95,
+        "exercises": [
+            {
+                "name": "Flat Bench Press",
+                "name_it": "Panca Piana",
+                "muscle_groups": ["chest", "triceps", "anterior deltoid"],
+                "difficulty": "intermediate",
+                "description": "Press the barbell upward from chest level.",
+            },
+            {
+                "name": "Close-Grip Bench Press",
+                "name_it": "Panca Presa Stretta",
+                "muscle_groups": ["triceps", "chest"],
+                "difficulty": "intermediate",
+                "description": "Narrow grip bench press targeting triceps.",
+            },
+        ],
+    }
+
+
 @pytest_asyncio.fixture
 async def client(fake_redis) -> AsyncGenerator[AsyncClient, None]:
-    """Create a test HTTP client with Redis mocked."""
-    with patch("app.redis_client.get_redis", return_value=fake_redis):
-        with patch(
-            "app.router.get_cached_vision_result", new_callable=AsyncMock, return_value=None
-        ):
-            transport = ASGITransport(app=app)
-            async with AsyncClient(transport=transport, base_url="http://test") as ac:
-                yield ac
+    """Create a test HTTP client with Redis and DB mocked."""
+    mock_db_session = AsyncMock()
+    mock_db_session.add = MagicMock()
+    mock_db_session.commit = AsyncMock()
+
+    async def mock_get_db():
+        yield mock_db_session
+
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.rate_limiter.get_redis", return_value=fake_redis),
+        patch("app.database.get_db", mock_get_db),
+        patch("app.router.get_db", mock_get_db),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac

--- a/services/ai/tests/test_claude_client.py
+++ b/services/ai/tests/test_claude_client.py
@@ -1,0 +1,233 @@
+"""Unit tests for Claude API client: vision scan and coach generation."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.claude_client import (
+    ClaudeAPIError,
+    _parse_json_response,
+    _resolve_media_type,
+    analyze_equipment_image,
+    generate_workout_plan,
+)
+
+
+class TestResolveMediaType:
+    """Tests for media type resolution."""
+
+    def test_jpeg_passthrough(self):
+        """Valid JPEG type should pass through unchanged."""
+        assert _resolve_media_type("image/jpeg") == "image/jpeg"
+
+    def test_png_passthrough(self):
+        """Valid PNG type should pass through unchanged."""
+        assert _resolve_media_type("image/png") == "image/png"
+
+    def test_gif_passthrough(self):
+        """Valid GIF type should pass through unchanged."""
+        assert _resolve_media_type("image/gif") == "image/gif"
+
+    def test_webp_passthrough(self):
+        """Valid WebP type should pass through unchanged."""
+        assert _resolve_media_type("image/webp") == "image/webp"
+
+    def test_invalid_type_defaults_to_jpeg(self):
+        """Invalid type should default to image/jpeg."""
+        assert _resolve_media_type("application/pdf") == "image/jpeg"
+
+    def test_empty_string_defaults_to_jpeg(self):
+        """Empty string should default to image/jpeg."""
+        assert _resolve_media_type("") == "image/jpeg"
+
+
+class TestParseJsonResponse:
+    """Tests for JSON response parsing from Claude."""
+
+    def test_parse_plain_json(self):
+        """Plain JSON string should parse correctly."""
+        text = '{"equipment_name": "Bench Press", "confidence": 0.9}'
+        result = _parse_json_response(text)
+        assert result["equipment_name"] == "Bench Press"
+
+    def test_parse_json_in_code_block(self):
+        """JSON inside markdown code block should parse correctly."""
+        text = '```json\n{"equipment_name": "Leg Press"}\n```'
+        result = _parse_json_response(text)
+        assert result["equipment_name"] == "Leg Press"
+
+    def test_parse_json_in_plain_code_block(self):
+        """JSON inside plain code block (no language tag) should parse correctly."""
+        text = '```\n{"equipment_name": "Cable Machine"}\n```'
+        result = _parse_json_response(text)
+        assert result["equipment_name"] == "Cable Machine"
+
+    def test_parse_json_with_whitespace(self):
+        """JSON with extra whitespace should parse correctly."""
+        text = '  \n  {"equipment_name": "Squat Rack"}  \n  '
+        result = _parse_json_response(text)
+        assert result["equipment_name"] == "Squat Rack"
+
+    def test_parse_invalid_json_raises(self):
+        """Non-JSON text should raise ClaudeAPIError."""
+        with pytest.raises(ClaudeAPIError, match="Failed to parse"):
+            _parse_json_response("This is not JSON at all")
+
+    def test_parse_empty_string_raises(self):
+        """Empty string should raise ClaudeAPIError."""
+        with pytest.raises(ClaudeAPIError, match="Failed to parse"):
+            _parse_json_response("")
+
+
+class TestAnalyzeEquipmentImage:
+    """Tests for Claude Vision API calls (mocked)."""
+
+    @pytest.mark.asyncio
+    async def test_analyze_success(self):
+        """Successful API call should return parsed result."""
+        mock_response = MagicMock()
+        mock_block = MagicMock()
+        mock_block.type = "text"
+        mock_block.text = json.dumps(
+            {
+                "equipment_name": "Bench Press",
+                "brand": "Technogym",
+                "confidence": 0.95,
+                "exercises": [],
+            }
+        )
+        mock_response.content = [mock_block]
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "app.claude_client._get_async_client", return_value=mock_client
+        ):
+            result = await analyze_equipment_image(
+                b"fake image data", "image/jpeg"
+            )
+            assert result["equipment_name"] == "Bench Press"
+            assert result["brand"] == "Technogym"
+
+    @pytest.mark.asyncio
+    async def test_analyze_empty_response_raises(self):
+        """Empty response from Claude should raise ClaudeAPIError."""
+        mock_response = MagicMock()
+        mock_response.content = []
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "app.claude_client._get_async_client", return_value=mock_client
+        ):
+            with pytest.raises(ClaudeAPIError, match="Empty response"):
+                await analyze_equipment_image(b"fake image", "image/jpeg")
+
+    @pytest.mark.asyncio
+    async def test_analyze_api_error_raises(self):
+        """API error should be wrapped in ClaudeAPIError."""
+        import anthropic
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(
+            side_effect=anthropic.APIError(
+                message="Rate limited",
+                request=MagicMock(),
+                body=None,
+            )
+        )
+
+        with patch(
+            "app.claude_client._get_async_client", return_value=mock_client
+        ):
+            with pytest.raises(ClaudeAPIError, match="Claude API error"):
+                await analyze_equipment_image(b"fake image", "image/jpeg")
+
+    @pytest.mark.asyncio
+    async def test_analyze_no_api_key_raises(self):
+        """Missing API key should raise ClaudeAPIError."""
+        with patch("app.claude_client.settings") as mock_settings:
+            mock_settings.anthropic_api_key = ""
+            with pytest.raises(ClaudeAPIError, match="not configured"):
+                await analyze_equipment_image(b"fake image", "image/jpeg")
+
+
+class TestGenerateWorkoutPlan:
+    """Tests for coach plan generation (mocked)."""
+
+    @pytest.mark.asyncio
+    async def test_generate_success(self):
+        """Successful plan generation should return parsed result."""
+        mock_response = MagicMock()
+        mock_block = MagicMock()
+        mock_block.type = "text"
+        mock_block.text = json.dumps(
+            {
+                "plan_name": "Beginner Full Body",
+                "description": "A 4-week beginner program",
+                "duration_weeks": 4,
+                "days_per_week": 3,
+                "level": "beginner",
+                "days": [{"day_name": "Day 1", "exercises": []}],
+                "progression_notes": "Add weight weekly",
+            }
+        )
+        mock_response.content = [mock_block]
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "app.claude_client._get_async_client", return_value=mock_client
+        ):
+            result = await generate_workout_plan(
+                photos_data=[(b"photo1", "image/jpeg")],
+                user_data={
+                    "name": "Test",
+                    "age": 30,
+                    "goals": {"primary": "muscle_gain"},
+                },
+            )
+            assert result["plan_name"] == "Beginner Full Body"
+            assert result["duration_weeks"] == 4
+            assert len(result["days"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_multiple_photos(self):
+        """Generation with multiple photos should include all in request."""
+        mock_response = MagicMock()
+        mock_block = MagicMock()
+        mock_block.type = "text"
+        mock_block.text = json.dumps(
+            {"plan_name": "Test Plan", "description": "test", "days": []}
+        )
+        mock_response.content = [mock_block]
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "app.claude_client._get_async_client", return_value=mock_client
+        ):
+            result = await generate_workout_plan(
+                photos_data=[
+                    (b"front_photo", "image/jpeg"),
+                    (b"side_photo", "image/png"),
+                    (b"back_photo", "image/jpeg"),
+                ],
+                user_data={"name": "Test"},
+            )
+            assert result["plan_name"] == "Test Plan"
+
+            # Verify all 3 photos + 1 text block were sent
+            call_args = mock_client.messages.create.call_args
+            content_blocks = call_args.kwargs["messages"][0]["content"]
+            image_blocks = [
+                b for b in content_blocks if b["type"] == "image"
+            ]
+            assert len(image_blocks) == 3

--- a/services/ai/tests/test_health.py
+++ b/services/ai/tests/test_health.py
@@ -11,9 +11,15 @@ from app.main import app
 
 
 @pytest.mark.asyncio
-async def test_health_check_redis_ok():
-    """Health check should return ok when Redis is reachable."""
-    with patch("app.redis_client.check_redis_health", new_callable=AsyncMock, return_value=True):
+async def test_health_check_all_ok():
+    """Health check should return ok when Redis and API key are available."""
+    with (
+        patch("app.redis_client.check_redis_health", new_callable=AsyncMock, return_value=True),
+        patch("app.main.settings") as mock_settings,
+    ):
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.service_name = "ai"
+        mock_settings.app_version = "0.1.0"
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.get("/health")
@@ -22,16 +28,43 @@ async def test_health_check_redis_ok():
             assert data["status"] == "ok"
             assert data["service"] == "ai"
             assert data["redis"] == "ok"
+            assert data["claude_api"] == "configured"
 
 
 @pytest.mark.asyncio
-async def test_health_check_redis_down():
-    """Health check should return degraded when Redis is unreachable."""
-    with patch("app.redis_client.check_redis_health", new_callable=AsyncMock, return_value=False):
+async def test_health_check_redis_ok_no_api_key():
+    """Health check should return degraded when API key missing but Redis ok."""
+    with (
+        patch("app.redis_client.check_redis_health", new_callable=AsyncMock, return_value=True),
+        patch("app.main.settings") as mock_settings,
+    ):
+        mock_settings.anthropic_api_key = ""
+        mock_settings.service_name = "ai"
+        mock_settings.app_version = "0.1.0"
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.get("/health")
             assert response.status_code == 200
             data = response.json()
             assert data["status"] == "degraded"
+            assert data["redis"] == "ok"
+            assert data["claude_api"] == "not_configured"
+
+
+@pytest.mark.asyncio
+async def test_health_check_redis_down():
+    """Health check should return unhealthy when Redis is unreachable."""
+    with (
+        patch("app.redis_client.check_redis_health", new_callable=AsyncMock, return_value=False),
+        patch("app.main.settings") as mock_settings,
+    ):
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.service_name = "ai"
+        mock_settings.app_version = "0.1.0"
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "unhealthy"
             assert data["redis"] == "unavailable"

--- a/services/ai/tests/test_prompts.py
+++ b/services/ai/tests/test_prompts.py
@@ -1,0 +1,92 @@
+"""Unit tests for prompt templates."""
+
+from __future__ import annotations
+
+from app.prompts.coach_generate import (
+    COACH_GENERATE_SYSTEM_PROMPT,
+    COACH_GENERATE_VERSION,
+    build_coach_user_prompt,
+)
+from app.prompts.vision_scan import (
+    VISION_SCAN_SYSTEM_PROMPT,
+    VISION_SCAN_USER_PROMPT,
+    VISION_SCAN_VERSION,
+)
+
+
+class TestVisionScanPrompt:
+    """Tests for vision scan prompt template."""
+
+    def test_system_prompt_has_json_schema(self):
+        """System prompt should describe the expected JSON schema."""
+        assert "equipment_name" in VISION_SCAN_SYSTEM_PROMPT
+        assert "exercises" in VISION_SCAN_SYSTEM_PROMPT
+        assert "confidence" in VISION_SCAN_SYSTEM_PROMPT
+        assert "brand" in VISION_SCAN_SYSTEM_PROMPT
+
+    def test_system_prompt_has_rules(self):
+        """System prompt should include behavior rules."""
+        assert "Unknown" in VISION_SCAN_SYSTEM_PROMPT
+        assert "0.0" in VISION_SCAN_SYSTEM_PROMPT
+        assert "JSON" in VISION_SCAN_SYSTEM_PROMPT
+
+    def test_user_prompt_asks_for_json(self):
+        """User prompt should request JSON output."""
+        assert "JSON" in VISION_SCAN_USER_PROMPT
+
+    def test_version_exists(self):
+        """Version string should be defined."""
+        assert VISION_SCAN_VERSION == "1.0"
+
+
+class TestCoachGeneratePrompt:
+    """Tests for coach generation prompt template."""
+
+    def test_system_prompt_has_plan_schema(self):
+        """System prompt should describe workout plan JSON schema."""
+        assert "plan_name" in COACH_GENERATE_SYSTEM_PROMPT
+        assert "days" in COACH_GENERATE_SYSTEM_PROMPT
+        assert "exercises" in COACH_GENERATE_SYSTEM_PROMPT
+        assert "sets" in COACH_GENERATE_SYSTEM_PROMPT
+        assert "reps" in COACH_GENERATE_SYSTEM_PROMPT
+
+    def test_version_exists(self):
+        """Version string should be defined."""
+        assert COACH_GENERATE_VERSION == "1.0"
+
+    def test_build_user_prompt_minimal(self):
+        """User prompt with minimal data should still be valid."""
+        prompt = build_coach_user_prompt({})
+        assert "Analyze" in prompt
+        assert "JSON" in prompt
+
+    def test_build_user_prompt_full(self):
+        """User prompt with all fields should include them all."""
+        prompt = build_coach_user_prompt(
+            {
+                "name": "Marco",
+                "age": 35,
+                "goals": {"primary": "muscle_gain", "secondary": "fat_loss"},
+                "limitations": {"shoulder": "avoid overhead"},
+                "experience": "intermediate",
+                "available_days": 4,
+                "available_equipment": "full gym",
+            }
+        )
+        assert "Marco" in prompt
+        assert "35" in prompt
+        assert "muscle_gain" in prompt
+        assert "shoulder" in prompt
+        assert "intermediate" in prompt
+        assert "4" in prompt
+        assert "full gym" in prompt
+
+    def test_build_user_prompt_goals_as_string(self):
+        """Goals provided as string should be included."""
+        prompt = build_coach_user_prompt({"goals": "lose weight"})
+        assert "lose weight" in prompt
+
+    def test_build_user_prompt_limitations_as_string(self):
+        """Limitations provided as string should be included."""
+        prompt = build_coach_user_prompt({"limitations": "bad knees"})
+        assert "bad knees" in prompt

--- a/services/ai/tests/test_rate_limiter.py
+++ b/services/ai/tests/test_rate_limiter.py
@@ -1,0 +1,105 @@
+"""Unit tests for rate limiter."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import fakeredis.aioredis
+import pytest
+
+from app.rate_limiter import (
+    RateLimitExceededError,
+    check_coach_generate_rate,
+    check_rate_limit,
+    check_vision_scan_rate,
+)
+
+
+@pytest.fixture
+def fake_redis():
+    """Create a fakeredis instance."""
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_first_request(fake_redis):
+    """First request should be allowed and return count 1."""
+    with patch("app.rate_limiter.get_redis", return_value=fake_redis):
+        count = await check_rate_limit("user-1", "test_op", 10, 3600)
+        assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_under_threshold(fake_redis):
+    """Multiple requests under the limit should all succeed."""
+    with patch("app.rate_limiter.get_redis", return_value=fake_redis):
+        for i in range(5):
+            count = await check_rate_limit("user-1", "test_op", 10, 3600)
+            assert count == i + 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_at_threshold(fake_redis):
+    """Request at exactly the limit should succeed."""
+    with patch("app.rate_limiter.get_redis", return_value=fake_redis):
+        for _ in range(10):
+            await check_rate_limit("user-1", "test_op", 10, 3600)
+
+        # 11th should fail
+        with pytest.raises(RateLimitExceededError):
+            await check_rate_limit("user-1", "test_op", 10, 3600)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_different_users(fake_redis):
+    """Rate limits should be per-user."""
+    with patch("app.rate_limiter.get_redis", return_value=fake_redis):
+        for _ in range(10):
+            await check_rate_limit("user-1", "test_op", 10, 3600)
+
+        # User 2 should still be allowed
+        count = await check_rate_limit("user-2", "test_op", 10, 3600)
+        assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_different_operations(fake_redis):
+    """Rate limits should be per-operation."""
+    with patch("app.rate_limiter.get_redis", return_value=fake_redis):
+        for _ in range(10):
+            await check_rate_limit("user-1", "op_a", 10, 3600)
+
+        # Same user, different operation should be allowed
+        count = await check_rate_limit("user-1", "op_b", 10, 3600)
+        assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_rate_limit(fake_redis):
+    """Vision scan rate limit should allow 10 per hour."""
+    with patch("app.rate_limiter.get_redis", return_value=fake_redis):
+        for _ in range(10):
+            await check_vision_scan_rate("user-1")
+
+        with pytest.raises(RateLimitExceededError):
+            await check_vision_scan_rate("user-1")
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_rate_limit(fake_redis):
+    """Coach generate rate limit should allow 3 per day."""
+    with patch("app.rate_limiter.get_redis", return_value=fake_redis):
+        for _ in range(3):
+            await check_coach_generate_rate("user-1")
+
+        with pytest.raises(RateLimitExceededError):
+            await check_coach_generate_rate("user-1")
+
+
+def test_rate_limit_error_message():
+    """Rate limit error should include operation and limit info."""
+    exc = RateLimitExceededError("vision_scan", 10, 3600)
+    assert "vision_scan" in str(exc)
+    assert "10" in str(exc)
+    assert exc.operation == "vision_scan"
+    assert exc.limit == 10

--- a/services/ai/tests/test_router.py
+++ b/services/ai/tests/test_router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import fakeredis.aioredis
 import pytest
@@ -27,53 +27,142 @@ def fake_redis():
     return fakeredis.aioredis.FakeRedis(decode_responses=True)
 
 
-@pytest.mark.asyncio
-async def test_vision_scan_submit(fake_redis, auth_headers):
-    """Submitting a vision scan should return a job_id."""
-    with patch("app.redis_client.get_redis", return_value=fake_redis):
-        with patch(
-            "app.router.get_cached_vision_result", new_callable=AsyncMock, return_value=None
-        ):
-            transport = ASGITransport(app=app)
-            async with AsyncClient(transport=transport, base_url="http://test") as client:
-                image_data = b"fake image data for testing"
-                response = await client.post(
-                    "/ai/vision/scan",
-                    files={"image": ("test.jpg", io.BytesIO(image_data), "image/jpeg")},
-                    headers=auth_headers,
-                )
-                assert response.status_code == 200
-                data = response.json()
-                assert "job_id" in data
-                assert data["status"] == "pending"
+@pytest.fixture
+def mock_vision_result():
+    """Mock result from process_vision_scan."""
+    return {
+        "equipment_name": "Bench Press",
+        "brand": "Technogym",
+        "confidence": 0.95,
+        "exercises": [
+            {
+                "name": "Flat Bench Press",
+                "name_it": "Panca Piana",
+                "muscle_groups": ["chest", "triceps"],
+                "difficulty": "intermediate",
+                "description": "Press barbell from chest.",
+            }
+        ],
+        "cached": False,
+        "scan_id": str(uuid.uuid4()),
+    }
+
+
+def _build_patches(fake_redis, vision_result=None, history_result=None):
+    """Build common patches for router tests."""
+    mock_db_session = AsyncMock()
+    mock_db_session.add = MagicMock()
+    mock_db_session.commit = AsyncMock()
+
+    async def mock_get_db():
+        yield mock_db_session
+
+    patches = [
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.rate_limiter.get_redis", return_value=fake_redis),
+        patch("app.router.get_db", mock_get_db),
+    ]
+
+    if vision_result is not None:
+        patches.append(
+            patch(
+                "app.router.process_vision_scan",
+                new_callable=AsyncMock,
+                return_value=vision_result,
+            )
+        )
+
+    if history_result is not None:
+        patches.append(
+            patch(
+                "app.router.get_vision_history",
+                new_callable=AsyncMock,
+                return_value=history_result,
+            )
+        )
+
+    return patches
 
 
 @pytest.mark.asyncio
-async def test_vision_scan_cached(fake_redis, auth_headers):
-    """Vision scan with cached result should return completed immediately."""
-    cached_result = {"equipment_name": "Bench Press", "confidence": 0.95}
-    with patch("app.redis_client.get_redis", return_value=fake_redis):
-        with patch(
-            "app.router.get_cached_vision_result",
-            new_callable=AsyncMock,
-            return_value=cached_result,
-        ):
-            transport = ASGITransport(app=app)
-            async with AsyncClient(transport=transport, base_url="http://test") as client:
-                response = await client.post(
-                    "/ai/vision/scan",
-                    files={"image": ("test.jpg", io.BytesIO(b"cached image"), "image/jpeg")},
-                    headers=auth_headers,
-                )
-                assert response.status_code == 200
-                data = response.json()
-                assert data["status"] == "completed"
+async def test_vision_scan_success(fake_redis, auth_headers, mock_vision_result):
+    """Submitting a valid vision scan should return equipment data."""
+    patches = _build_patches(fake_redis, vision_result=mock_vision_result)
+
+    with patches[0], patches[1], patches[2], patches[3]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            image_data = b"\xff\xd8\xff\xe0" + b"\x00" * 100  # JPEG header
+            response = await client.post(
+                "/ai/vision/scan",
+                files={"image": ("test.jpg", io.BytesIO(image_data), "image/jpeg")},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["equipment_name"] == "Bench Press"
+            assert abs(data["confidence"] - 0.95) < 1e-9
+            assert len(data["exercises"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_invalid_content_type(fake_redis, auth_headers):
+    """Submitting a non-image file should return 400."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ai/vision/scan",
+                files={"image": ("test.pdf", io.BytesIO(b"data"), "application/pdf")},
+                headers=auth_headers,
+            )
+            assert response.status_code == 400
+            assert "Invalid image type" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_empty_file(fake_redis, auth_headers):
+    """Submitting an empty image should return 400."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ai/vision/scan",
+                files={"image": ("test.jpg", io.BytesIO(b""), "image/jpeg")},
+                headers=auth_headers,
+            )
+            assert response.status_code == 400
+            assert "Empty" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_too_large(fake_redis, auth_headers):
+    """Submitting an oversized image should return 413."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # 11 MB file
+            big_data = b"\x00" * (11 * 1024 * 1024)
+            response = await client.post(
+                "/ai/vision/scan",
+                files={"image": ("big.jpg", io.BytesIO(big_data), "image/jpeg")},
+                headers=auth_headers,
+            )
+            assert response.status_code == 413
 
 
 @pytest.mark.asyncio
 async def test_vision_scan_no_auth(fake_redis):
-    """Vision scan without auth should return 401."""
-    with patch("app.redis_client.get_redis", return_value=fake_redis):
+    """Vision scan without auth should return 401/403."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post(
@@ -84,64 +173,189 @@ async def test_vision_scan_no_auth(fake_redis):
 
 
 @pytest.mark.asyncio
-async def test_coach_generate_submit(fake_redis, auth_headers):
-    """Submitting a coach generation should return a job_id."""
-    with patch("app.redis_client.get_redis", return_value=fake_redis):
+async def test_vision_scan_rate_limited(fake_redis, auth_headers):
+    """Vision scan should return 429 when rate limit exceeded."""
+    from app.rate_limiter import RateLimitExceededError
+
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        with patch(
+            "app.router.check_vision_scan_rate",
+            new_callable=AsyncMock,
+            side_effect=RateLimitExceededError("vision_scan", 10, 3600),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/ai/vision/scan",
+                    files={
+                        "image": (
+                            "test.jpg",
+                            io.BytesIO(b"\xff\xd8" + b"\x00" * 10),
+                            "image/jpeg",
+                        )
+                    },
+                    headers=auth_headers,
+                )
+                assert response.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_vision_scan_insufficient_credits(fake_redis, auth_headers):
+    """Vision scan should return 402 when credits are insufficient."""
+    from app.service import InsufficientCreditsError
+
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        with patch(
+            "app.router.process_vision_scan",
+            new_callable=AsyncMock,
+            side_effect=InsufficientCreditsError(),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/ai/vision/scan",
+                    files={
+                        "image": (
+                            "test.jpg",
+                            io.BytesIO(b"\xff\xd8" + b"\x00" * 10),
+                            "image/jpeg",
+                        )
+                    },
+                    headers=auth_headers,
+                )
+                assert response.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_vision_history_empty(fake_redis, auth_headers):
+    """Vision history for new user should return empty list."""
+    history_result = {"items": [], "total": 0, "page": 1, "per_page": 20, "pages": 0}
+    patches = _build_patches(fake_redis, history_result=history_result)
+
+    with patches[0], patches[1], patches[2], patches[3]:
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            response = await client.post("/ai/coach/generate", headers=auth_headers)
+            response = await client.get(
+                "/ai/vision/history",
+                headers=auth_headers,
+            )
             assert response.status_code == 200
             data = response.json()
-            assert "job_id" in data
-            assert data["status"] == "pending"
+            assert data["total"] == 0
+            assert data["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_vision_history_with_items(fake_redis, auth_headers):
+    """Vision history should return paginated items."""
+    history_result = {
+        "items": [
+            {
+                "id": str(uuid.uuid4()),
+                "image_hash": "abc123",
+                "equipment_name": "Leg Press",
+                "equipment_brand": None,
+                "exercises": [{"name": "Leg Press"}],
+                "credits_used": 1,
+                "error": None,
+                "created_at": "2026-04-06T10:00:00+00:00",
+            }
+        ],
+        "total": 1,
+        "page": 1,
+        "per_page": 20,
+        "pages": 1,
+    }
+    patches = _build_patches(fake_redis, history_result=history_result)
+
+    with patches[0], patches[1], patches[2], patches[3]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/ai/vision/history",
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            assert data["items"][0]["equipment_name"] == "Leg Press"
 
 
 @pytest.mark.asyncio
 async def test_get_job_status(fake_redis, auth_headers):
     """Getting a submitted job should return its status."""
-    with patch("app.redis_client.get_redis", return_value=fake_redis):
-        with patch(
-            "app.router.get_cached_vision_result", new_callable=AsyncMock, return_value=None
-        ):
-            transport = ASGITransport(app=app)
-            async with AsyncClient(transport=transport, base_url="http://test") as client:
-                # Submit a job
-                submit = await client.post("/ai/coach/generate", headers=auth_headers)
-                job_id = submit.json()["job_id"]
+    from app.redis_client import publish_job
 
-                # Check status
-                response = await client.get(f"/ai/jobs/{job_id}", headers=auth_headers)
-                assert response.status_code == 200
-                data = response.json()
-                assert data["job_id"] == job_id
-                assert data["status"] == "pending"
-                assert data["job_type"] == "coach_generate"
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.rate_limiter.get_redis", return_value=fake_redis),
+    ):
+        # Publish a test job
+        job_id = await publish_job("vision_scan", TEST_USER_ID, {"test": True})
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(f"/ai/jobs/{job_id}", headers=auth_headers)
+            assert response.status_code == 200
+            data = response.json()
+            assert data["job_id"] == job_id
+            assert data["status"] == "pending"
 
 
 @pytest.mark.asyncio
 async def test_get_job_not_found(fake_redis, auth_headers):
     """Getting a nonexistent job should return 404."""
-    with patch("app.redis_client.get_redis", return_value=fake_redis):
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.rate_limiter.get_redis", return_value=fake_redis),
+    ):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            response = await client.get(f"/ai/jobs/{uuid.uuid4()}", headers=auth_headers)
+            response = await client.get(
+                f"/ai/jobs/{uuid.uuid4()}", headers=auth_headers
+            )
             assert response.status_code == 404
 
 
 @pytest.mark.asyncio
 async def test_get_job_other_user(fake_redis):
     """Getting another user's job should return 404."""
+    from app.redis_client import publish_job
+
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.rate_limiter.get_redis", return_value=fake_redis),
+    ):
+        # Submit as user A
+        user_a = str(uuid.uuid4())
+        job_id = await publish_job("vision_scan", user_a, {"test": True})
+
+        # Try to access as user B
+        user_b = str(uuid.uuid4())
+        headers_b = {"Authorization": f"Bearer {create_test_token(user_b)}"}
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(f"/ai/jobs/{job_id}", headers=headers_b)
+            assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_health_check(fake_redis):
+    """Health check should return service status."""
     with patch("app.redis_client.get_redis", return_value=fake_redis):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
-            # Submit as user A
-            user_a = str(uuid.uuid4())
-            headers_a = {"Authorization": f"Bearer {create_test_token(user_a)}"}
-            submit = await client.post("/ai/coach/generate", headers=headers_a)
-            job_id = submit.json()["job_id"]
-
-            # Try to access as user B
-            user_b = str(uuid.uuid4())
-            headers_b = {"Authorization": f"Bearer {create_test_token(user_b)}"}
-            response = await client.get(f"/ai/jobs/{job_id}", headers=headers_b)
-            assert response.status_code == 404
+            response = await client.get("/health")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["service"] == "ai"
+            assert "status" in data

--- a/services/ai/tests/test_service.py
+++ b/services/ai/tests/test_service.py
@@ -1,0 +1,164 @@
+"""Unit tests for AI service business logic."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import fakeredis.aioredis
+import pytest
+
+from app.service import (
+    AIServiceError,
+    InsufficientCreditsError,
+    process_vision_scan,
+)
+from tests.conftest import TEST_USER_ID, create_test_token
+
+
+@pytest.fixture
+def fake_redis():
+    """Create a fakeredis instance."""
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock database session."""
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def auth_token():
+    """Create a valid JWT token."""
+    return create_test_token(TEST_USER_ID)
+
+
+@pytest.fixture
+def vision_result():
+    """Standard vision scan result."""
+    return {
+        "equipment_name": "Bench Press",
+        "brand": "Technogym",
+        "confidence": 0.95,
+        "exercises": [
+            {
+                "name": "Flat Bench Press",
+                "name_it": "Panca Piana",
+                "muscle_groups": ["chest"],
+                "difficulty": "intermediate",
+                "description": "Press barbell from chest.",
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_vision_scan_success(fake_redis, mock_db, auth_token, vision_result):
+    """Successful vision scan should call Claude API and persist result."""
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.service.get_cached_vision_result", new_callable=AsyncMock, return_value=None),
+        patch(
+            "app.service.analyze_equipment_image",
+            new_callable=AsyncMock,
+            return_value=vision_result,
+        ),
+        patch("app.service._deduct_credits", new_callable=AsyncMock, return_value=True),
+        patch("app.service.cache_vision_result", new_callable=AsyncMock),
+    ):
+        result = await process_vision_scan(
+            image_data=b"fake image bytes",
+            content_type="image/jpeg",
+            user_id=TEST_USER_ID,
+            token=auth_token,
+            db=mock_db,
+        )
+
+        assert result["equipment_name"] == "Bench Press"
+        assert result["cached"] is False
+        assert "scan_id" in result
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_vision_scan_cached(fake_redis, mock_db, auth_token, vision_result):
+    """Cached vision scan should skip Claude API and not deduct credits."""
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch(
+            "app.service.get_cached_vision_result",
+            new_callable=AsyncMock,
+            return_value=vision_result,
+        ),
+        patch(
+            "app.service.analyze_equipment_image", new_callable=AsyncMock
+        ) as mock_analyze,
+        patch("app.service._deduct_credits", new_callable=AsyncMock) as mock_deduct,
+    ):
+        result = await process_vision_scan(
+            image_data=b"cached image",
+            content_type="image/jpeg",
+            user_id=TEST_USER_ID,
+            token=auth_token,
+            db=mock_db,
+        )
+
+        assert result["cached"] is True
+        # Should NOT call Claude API or deduct credits
+        mock_analyze.assert_not_called()
+        mock_deduct.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_vision_scan_insufficient_credits(fake_redis, mock_db, auth_token):
+    """Vision scan should raise when user has no credits."""
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.service.get_cached_vision_result", new_callable=AsyncMock, return_value=None),
+        patch(
+            "app.service._deduct_credits",
+            new_callable=AsyncMock,
+            side_effect=InsufficientCreditsError(),
+        ),
+    ):
+        with pytest.raises(InsufficientCreditsError):
+            await process_vision_scan(
+                image_data=b"image",
+                content_type="image/jpeg",
+                user_id=TEST_USER_ID,
+                token=auth_token,
+                db=mock_db,
+            )
+
+
+@pytest.mark.asyncio
+async def test_process_vision_scan_api_failure(fake_redis, mock_db, auth_token):
+    """Claude API failure should save error to DB and raise."""
+    from app.claude_client import ClaudeAPIError
+
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.service.get_cached_vision_result", new_callable=AsyncMock, return_value=None),
+        patch("app.service._deduct_credits", new_callable=AsyncMock, return_value=True),
+        patch(
+            "app.service.analyze_equipment_image",
+            new_callable=AsyncMock,
+            side_effect=ClaudeAPIError("API timeout"),
+        ),
+    ):
+        with pytest.raises(AIServiceError, match="Vision scan failed"):
+            await process_vision_scan(
+                image_data=b"image",
+                content_type="image/jpeg",
+                user_id=TEST_USER_ID,
+                token=auth_token,
+                db=mock_db,
+            )
+
+        # Error should still be saved to DB
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()


### PR DESCRIPTION
## Summary
- Full AI Vision scan backend: POST /ai/vision/scan accepts JPEG/PNG photos, sends to Claude Vision API, returns structured equipment recognition (name, brand, exercises)
- Versioned prompt templates in `services/ai/app/prompts/` for both vision scan and coach generation
- Per-user rate limiting (10 scans/hour) via Redis, credit deduction (1 credit/scan) via auth service
- SHA256 image hash caching — cached results skip API call and credit cost
- GET /ai/vision/history with pagination for scan history
- Database models (ai_vision_scans, ai_coach_generations) for persistence
- Photos processed in memory only, never saved to disk (ADR-003)
- Enhanced health check reporting Claude API key configuration status

## Test plan
- [x] 62 tests passing (claude_client, prompts, rate_limiter, service, router, health)
- [x] All 4 services pass (124 total tests across auth, workouts, ai, analytics)
- [x] Ruff linter clean
- [x] Content type validation (only JPEG/PNG accepted)
- [x] Size validation (max 10MB)
- [x] Rate limit returns 429 when exceeded
- [x] Insufficient credits returns 402
- [x] Cache hit skips API call and credits
- [x] Job ownership verified (other users get 404)

Closes #14