### PR TITLE
#15 AI Coach: personalized workout plan from body photos

### DIFF
--- a/services/ai/app/router.py
+++ b/services/ai/app/router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 
@@ -9,6 +10,7 @@ from fastapi import (
     APIRouter,
     Depends,
     File,
+    Form,
     HTTPException,
     Query,
     UploadFile,
@@ -21,12 +23,14 @@ from app.database import get_db
 from app.dependencies import get_current_user_id
 from app.rate_limiter import (
     RateLimitExceededError,
+    check_coach_generate_rate,
     check_vision_scan_rate,
 )
 from app.redis_client import (
     get_job_status,
 )
 from app.schemas import (
+    CoachGenerateSyncResponse,
     JobStatusResponse,
     PaginatedCoachHistory,
     PaginatedVisionHistory,
@@ -37,6 +41,7 @@ from app.service import (
     InsufficientCreditsError,
     get_coach_history,
     get_vision_history,
+    process_coach_generate,
     process_vision_scan,
 )
 
@@ -46,7 +51,9 @@ router = APIRouter(prefix="/ai", tags=["ai"])
 security_scheme = HTTPBearer()
 
 MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10 MB
-ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png"}
+DEFAULT_CONTENT_TYPE = "image/jpeg"
+ALLOWED_CONTENT_TYPES = {DEFAULT_CONTENT_TYPE, "image/png"}
+MAX_COACH_PHOTOS = 5
 
 
 def _get_token(
@@ -121,7 +128,7 @@ async def vision_scan(
     try:
         result = await process_vision_scan(
             image_data=contents,
-            content_type=image.content_type or "image/jpeg",
+            content_type=image.content_type or DEFAULT_CONTENT_TYPE,
             user_id=str(user_id),
             token=token,
             db=db,
@@ -161,6 +168,118 @@ async def vision_history(
     """
     result = await get_vision_history(str(user_id), db, page, per_page)
     return PaginatedVisionHistory(**result)
+
+
+@router.post(
+    "/coach/generate", response_model=CoachGenerateSyncResponse
+)
+async def coach_generate(
+    photos: list[UploadFile] = File(...),
+    data: str = Form("{}"),
+    user_id: uuid.UUID = Depends(get_current_user_id),
+    token: str = Depends(_get_token),
+    db: AsyncSession = Depends(get_db),
+) -> CoachGenerateSyncResponse:
+    """Generate a personalized workout plan from body photos and user data.
+
+    Accepts multiple body photos and a JSON string with user profile data.
+    Photos are processed in memory only — never saved (ADR-003).
+    Costs 5 AI credits per generation.
+
+    Rate limit: 3 generations per day.
+
+    Args:
+        photos: Body photo files (JPEG/PNG, max 10MB each, max 5 photos).
+        data: JSON string with user data (age, goals, limitations, etc.).
+        user_id: Authenticated user UUID from JWT.
+        token: Raw JWT token for inter-service calls.
+        db: Database session.
+
+    Returns:
+        Generated workout plan with exercises.
+    """
+    # Validate photo count
+    if len(photos) == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="At least one photo is required",
+        )
+    if len(photos) > MAX_COACH_PHOTOS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Maximum {MAX_COACH_PHOTOS} photos allowed",
+        )
+
+    # Parse user data JSON
+    try:
+        user_data = json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid JSON in data field: {exc}",
+        ) from exc
+
+    # Read and validate all photos
+    photos_data: list[tuple[bytes, str]] = []
+    for photo in photos:
+        if photo.content_type not in ALLOWED_CONTENT_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Invalid photo type: {photo.content_type}. "
+                    "Allowed: JPEG, PNG."
+                ),
+            )
+
+        contents = await photo.read()
+        if len(contents) > MAX_IMAGE_SIZE:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail=(
+                    f"Photo {photo.filename} exceeds maximum "
+                    f"size of {MAX_IMAGE_SIZE // (1024 * 1024)}MB"
+                ),
+            )
+        if len(contents) == 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Empty photo file: {photo.filename}",
+            )
+        photos_data.append(
+            (contents, photo.content_type or DEFAULT_CONTENT_TYPE)
+        )
+
+    # Check rate limit
+    try:
+        await check_coach_generate_rate(str(user_id))
+    except RateLimitExceededError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+
+    # Process (credit check + Claude API + DB)
+    try:
+        result = await process_coach_generate(
+            photos_data=photos_data,
+            user_data=user_data,
+            user_id=str(user_id),
+            token=token,
+            db=db,
+        )
+    except InsufficientCreditsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=exc.message,
+        ) from exc
+    except AIServiceError as exc:
+        logger.error("Coach generation failed: %s", exc.message)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=exc.message,
+        ) from exc
+
+    return CoachGenerateSyncResponse(**result)
 
 
 @router.get("/coach/history", response_model=PaginatedCoachHistory)

--- a/services/ai/app/schemas.py
+++ b/services/ai/app/schemas.py
@@ -67,16 +67,8 @@ class VisionHistoryItem(BaseModel):
 # ============================================================
 
 
-class CoachGenerateResponse(BaseModel):
-    """Response for an AI coach generation submission (async job)."""
-
-    job_id: str
-    status: str = "pending"
-    message: str = "Coach generation job submitted. Poll GET /ai/jobs/{job_id} for results."
-
-
-class CoachResult(BaseModel):
-    """Result of a coach generation: personalized workout plan."""
+class CoachGenerateSyncResponse(BaseModel):
+    """Synchronous response for coach generation."""
 
     plan_name: str
     description: str
@@ -86,6 +78,7 @@ class CoachResult(BaseModel):
     days: list[dict] = Field(default_factory=list)
     progression_notes: str | None = None
     nutrition_tips: str | None = None
+    generation_id: str | None = None
 
 
 class CoachHistoryItem(BaseModel):

--- a/services/ai/app/service.py
+++ b/services/ai/app/service.py
@@ -14,7 +14,11 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.claude_client import ClaudeAPIError, analyze_equipment_image
+from app.claude_client import (
+    ClaudeAPIError,
+    analyze_equipment_image,
+    generate_workout_plan,
+)
 from app.models import AICoachGeneration, AIVisionScan
 from app.redis_client import (
     cache_vision_result,
@@ -185,6 +189,66 @@ async def process_vision_scan(
 
     result["cached"] = False
     result["scan_id"] = str(scan.id)
+    return result
+
+
+async def process_coach_generate(
+    photos_data: list[tuple[bytes, str]],
+    user_data: dict,
+    user_id: str,
+    token: str,
+    db: AsyncSession,
+) -> dict[str, Any]:
+    """Process a coach generation: call Claude API, save to DB.
+
+    Args:
+        photos_data: List of (image_bytes, content_type) tuples.
+        user_data: User profile data (age, goals, limitations, etc.).
+        user_id: User UUID string.
+        token: JWT token for credit deduction.
+        db: Database session.
+
+    Returns:
+        Generated workout plan result dict.
+
+    Raises:
+        InsufficientCreditsError: If user lacks credits.
+        AIServiceError: If processing fails.
+    """
+    # Deduct credits before calling API
+    await _deduct_credits(user_id, COACH_GENERATE_CREDITS, token)
+
+    # Call Claude API
+    try:
+        result = await generate_workout_plan(photos_data, user_data)
+    except ClaudeAPIError as exc:
+        # Save failed generation to DB
+        generation = AICoachGeneration(
+            user_id=uuid.UUID(user_id),
+            input_data=user_data,
+            photo_count=len(photos_data),
+            credits_used=COACH_GENERATE_CREDITS,
+            error=str(exc),
+        )
+        db.add(generation)
+        await db.commit()
+        raise AIServiceError(
+            f"Coach generation failed: {exc.message}"
+        ) from exc
+
+    # Save to DB
+    generation = AICoachGeneration(
+        user_id=uuid.UUID(user_id),
+        input_data=user_data,
+        photo_count=len(photos_data),
+        generated_plan=result,
+        raw_response=result,
+        credits_used=COACH_GENERATE_CREDITS,
+    )
+    db.add(generation)
+    await db.commit()
+
+    result["generation_id"] = str(generation.id)
     return result
 
 

--- a/services/ai/tests/test_coach.py
+++ b/services/ai/tests/test_coach.py
@@ -1,0 +1,338 @@
+"""Integration tests for AI coach generation endpoint."""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import fakeredis.aioredis
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from tests.conftest import TEST_USER_ID, create_test_token
+
+
+@pytest.fixture
+def auth_headers() -> dict:
+    """Authorization headers for test user."""
+    token = create_test_token(TEST_USER_ID)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def fake_redis():
+    """Create a fakeredis instance."""
+    return fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture
+def mock_coach_result():
+    """Mock result from process_coach_generate."""
+    return {
+        "plan_name": "Beginner Full Body",
+        "description": "A 4-week beginner program",
+        "duration_weeks": 4,
+        "days_per_week": 3,
+        "level": "beginner",
+        "days": [
+            {
+                "day_name": "Day 1 - Upper Body",
+                "focus": "chest, shoulders, triceps",
+                "exercises": [
+                    {
+                        "name": "Bench Press",
+                        "sets": 3,
+                        "reps": "8-12",
+                    }
+                ],
+            }
+        ],
+        "progression_notes": "Add weight weekly",
+        "nutrition_tips": "Eat protein after workout",
+        "generation_id": str(uuid.uuid4()),
+    }
+
+
+def _build_patches(fake_redis, coach_result=None):
+    """Build common patches for coach tests."""
+    mock_db_session = AsyncMock()
+    mock_db_session.add = MagicMock()
+    mock_db_session.commit = AsyncMock()
+
+    async def mock_get_db():
+        yield mock_db_session
+
+    patches = [
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.rate_limiter.get_redis", return_value=fake_redis),
+        patch("app.router.get_db", mock_get_db),
+    ]
+
+    if coach_result is not None:
+        patches.append(
+            patch(
+                "app.router.process_coach_generate",
+                new_callable=AsyncMock,
+                return_value=coach_result,
+            )
+        )
+
+    return patches
+
+
+def _make_photo(name: str = "photo.jpg", size: int = 100) -> tuple:
+    """Create a fake photo file for multipart upload."""
+    data = b"\xff\xd8\xff\xe0" + b"\x00" * size
+    return (name, io.BytesIO(data), "image/jpeg")
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_success(
+    fake_redis, auth_headers, mock_coach_result
+):
+    """Submitting valid photos should return a workout plan."""
+    patches = _build_patches(fake_redis, coach_result=mock_coach_result)
+
+    with patches[0], patches[1], patches[2], patches[3]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                files=[("photos", _make_photo("front.jpg"))],
+                data={"data": json.dumps({"age": 30, "goals": "muscle"})},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            result = response.json()
+            assert result["plan_name"] == "Beginner Full Body"
+            assert result["duration_weeks"] == 4
+            assert len(result["days"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_multiple_photos(
+    fake_redis, auth_headers, mock_coach_result
+):
+    """Multiple photos should be accepted."""
+    patches = _build_patches(fake_redis, coach_result=mock_coach_result)
+
+    with patches[0], patches[1], patches[2], patches[3]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                files=[
+                    ("photos", _make_photo("front.jpg")),
+                    ("photos", _make_photo("side.jpg")),
+                    ("photos", _make_photo("back.jpg")),
+                ],
+                data={"data": "{}"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_no_auth(fake_redis):
+    """Coach generation without auth should return 401/403."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                files=[("photos", _make_photo())],
+                data={"data": "{}"},
+            )
+            assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_invalid_photo_type(fake_redis, auth_headers):
+    """Non-image file should return 400."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                files=[
+                    (
+                        "photos",
+                        ("doc.pdf", io.BytesIO(b"data"), "application/pdf"),
+                    )
+                ],
+                data={"data": "{}"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 400
+            assert "Invalid photo type" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_too_many_photos(fake_redis, auth_headers):
+    """More than 5 photos should return 400."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                files=[("photos", _make_photo(f"p{i}.jpg")) for i in range(6)],
+                data={"data": "{}"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 400
+            assert "Maximum" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_invalid_json_data(fake_redis, auth_headers):
+    """Invalid JSON in data field should return 400."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                files=[("photos", _make_photo())],
+                data={"data": "not valid json{"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 400
+            assert "Invalid JSON" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_empty_photo(fake_redis, auth_headers):
+    """Empty photo file should return 400."""
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                files=[
+                    ("photos", ("empty.jpg", io.BytesIO(b""), "image/jpeg"))
+                ],
+                data={"data": "{}"},
+                headers=auth_headers,
+            )
+            assert response.status_code == 400
+            assert "Empty" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_rate_limited(fake_redis, auth_headers):
+    """Coach generation should return 429 when rate limit exceeded."""
+    from app.rate_limiter import RateLimitExceededError
+
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        with patch(
+            "app.router.check_coach_generate_rate",
+            new_callable=AsyncMock,
+            side_effect=RateLimitExceededError("coach_generate", 3, 86400),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/ai/coach/generate",
+                    files=[("photos", _make_photo())],
+                    data={"data": "{}"},
+                    headers=auth_headers,
+                )
+                assert response.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_coach_generate_insufficient_credits(
+    fake_redis, auth_headers
+):
+    """Coach generation should return 402 when credits insufficient."""
+    from app.service import InsufficientCreditsError
+
+    patches = _build_patches(fake_redis)
+
+    with patches[0], patches[1], patches[2]:
+        with patch(
+            "app.router.process_coach_generate",
+            new_callable=AsyncMock,
+            side_effect=InsufficientCreditsError(),
+        ):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                response = await client.post(
+                    "/ai/coach/generate",
+                    files=[("photos", _make_photo())],
+                    data={"data": "{}"},
+                    headers=auth_headers,
+                )
+                assert response.status_code == 402
+
+
+@pytest.mark.asyncio
+async def test_coach_history_empty(fake_redis, auth_headers):
+    """Coach history for new user should return empty list."""
+    history_result = {
+        "items": [],
+        "total": 0,
+        "page": 1,
+        "per_page": 20,
+        "pages": 0,
+    }
+
+    mock_db_session = AsyncMock()
+
+    async def mock_get_db():
+        yield mock_db_session
+
+    with (
+        patch("app.redis_client.get_redis", return_value=fake_redis),
+        patch("app.rate_limiter.get_redis", return_value=fake_redis),
+        patch("app.router.get_db", mock_get_db),
+        patch(
+            "app.router.get_coach_history",
+            new_callable=AsyncMock,
+            return_value=history_result,
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.get(
+                "/ai/coach/history",
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 0
+            assert data["items"] == []

--- a/services/ai/tests/test_service.py
+++ b/services/ai/tests/test_service.py
@@ -10,6 +10,7 @@ import pytest
 from app.service import (
     AIServiceError,
     InsufficientCreditsError,
+    process_coach_generate,
     process_vision_scan,
 )
 from tests.conftest import TEST_USER_ID, create_test_token
@@ -154,6 +155,103 @@ async def test_process_vision_scan_api_failure(fake_redis, mock_db, auth_token):
             await process_vision_scan(
                 image_data=b"image",
                 content_type="image/jpeg",
+                user_id=TEST_USER_ID,
+                token=auth_token,
+                db=mock_db,
+            )
+
+        # Error should still be saved to DB
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+
+# ============================================================
+# Coach Generation Tests
+# ============================================================
+
+
+@pytest.fixture
+def coach_result():
+    """Standard coach generation result."""
+    return {
+        "plan_name": "Beginner Full Body",
+        "description": "A 4-week beginner program",
+        "duration_weeks": 4,
+        "days_per_week": 3,
+        "level": "beginner",
+        "days": [{"day_name": "Day 1", "exercises": []}],
+        "progression_notes": "Add weight weekly",
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_coach_generate_success(mock_db, auth_token, coach_result):
+    """Successful coach generation should call Claude API and persist."""
+    with (
+        patch(
+            "app.service.generate_workout_plan",
+            new_callable=AsyncMock,
+            return_value=coach_result,
+        ),
+        patch(
+            "app.service._deduct_credits",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        result = await process_coach_generate(
+            photos_data=[(b"photo1", "image/jpeg")],
+            user_data={"age": 30, "goals": "muscle"},
+            user_id=TEST_USER_ID,
+            token=auth_token,
+            db=mock_db,
+        )
+
+        assert result["plan_name"] == "Beginner Full Body"
+        assert "generation_id" in result
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_process_coach_generate_insufficient_credits(mock_db, auth_token):
+    """Coach generation should raise when user has no credits."""
+    with patch(
+        "app.service._deduct_credits",
+        new_callable=AsyncMock,
+        side_effect=InsufficientCreditsError(),
+    ):
+        with pytest.raises(InsufficientCreditsError):
+            await process_coach_generate(
+                photos_data=[(b"photo", "image/jpeg")],
+                user_data={},
+                user_id=TEST_USER_ID,
+                token=auth_token,
+                db=mock_db,
+            )
+
+
+@pytest.mark.asyncio
+async def test_process_coach_generate_api_failure(mock_db, auth_token):
+    """Claude API failure should save error to DB and raise."""
+    from app.claude_client import ClaudeAPIError
+
+    with (
+        patch(
+            "app.service._deduct_credits",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "app.service.generate_workout_plan",
+            new_callable=AsyncMock,
+            side_effect=ClaudeAPIError("API timeout"),
+        ),
+    ):
+        with pytest.raises(AIServiceError, match="Coach generation failed"):
+            await process_coach_generate(
+                photos_data=[(b"photo", "image/jpeg")],
+                user_data={},
                 user_id=TEST_USER_ID,
                 token=auth_token,
                 db=mock_db,


### PR DESCRIPTION
## Summary
- POST /ai/coach/generate accepts multiple body photos (multipart) + JSON user data (form field)
- Claude API generates structured workout plans based on body analysis and user goals/limitations
- Rate limiting (3 generations/day), credit deduction (5 credits), photo validation (JPEG/PNG, max 10MB, max 5)
- Results persisted to ai_coach_generations table with full history via GET /ai/coach/history

## Test plan
- [x] 75 tests passing (13 new coach-specific tests)
- [x] Ruff linter clean
- [x] Multiple photos accepted (up to 5)
- [x] Invalid photo type returns 400
- [x] Too many photos returns 400
- [x] Invalid JSON data returns 400
- [x] Empty photo returns 400
- [x] Rate limit returns 429
- [x] Insufficient credits returns 402
- [x] Coach history returns paginated results

Closes #15