### PR TITLE
#33 Traefik HTTPS with Let's Encrypt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,7 @@ APP_ENV=development
 APP_DEBUG=true
 APP_VERSION=0.1.0
 CORS_ORIGINS=http://localhost:3000,http://localhost:8080
+
+# Production — Traefik HTTPS (used by docker-compose.prod.yml)
+DOMAIN=fitnessai.app
+ACME_EMAIL=admin@fitnessai.app

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,82 @@
+# Production docker-compose override
+# Usage: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Prerequisites:
+# - Set DOMAIN=fitnessai.app in .env
+# - Set ACME_EMAIL=admin@fitnessai.app in .env
+# - Ensure DNS A record points to the server IP
+
+version: "3.9"
+
+services:
+  traefik:
+    ports:
+      - "80:80"
+      - "443:443"
+      # Dashboard port removed in production
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./infra/traefik/traefik.prod.yml:/etc/traefik/traefik.yml:ro
+      - ./infra/traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+      - letsencrypt:/letsencrypt
+
+  auth:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.auth.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/auth`)"
+      - "traefik.http.routers.auth.entrypoints=websecure"
+      - "traefik.http.routers.auth.tls=true"
+      - "traefik.http.routers.auth.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.auth.middlewares=security-headers@file,rate-limit-auth@file"
+      - "traefik.http.services.auth.loadbalancer.server.port=8001"
+
+  workouts:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.workouts.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/workouts`)"
+      - "traefik.http.routers.workouts.entrypoints=websecure"
+      - "traefik.http.routers.workouts.tls=true"
+      - "traefik.http.routers.workouts.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.workouts.middlewares=security-headers@file,rate-limit-global@file"
+      - "traefik.http.services.workouts.loadbalancer.server.port=8002"
+
+  ai:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ai.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/ai`)"
+      - "traefik.http.routers.ai.entrypoints=websecure"
+      - "traefik.http.routers.ai.tls=true"
+      - "traefik.http.routers.ai.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.ai.middlewares=security-headers@file,rate-limit-ai@file,body-limit@file"
+      - "traefik.http.services.ai.loadbalancer.server.port=8003"
+
+  analytics:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.analytics.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/analytics`)"
+      - "traefik.http.routers.analytics.entrypoints=websecure"
+      - "traefik.http.routers.analytics.tls=true"
+      - "traefik.http.routers.analytics.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.analytics.middlewares=security-headers@file,rate-limit-global@file"
+      - "traefik.http.services.analytics.loadbalancer.server.port=8004"
+
+  web:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.web.rule=Host(`${DOMAIN:-fitnessai.app}`)"
+      - "traefik.http.routers.web.entrypoints=websecure"
+      - "traefik.http.routers.web.tls=true"
+      - "traefik.http.routers.web.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.web.priority=1"
+      - "traefik.http.services.web.loadbalancer.server.port=3000"
+
+  db:
+    # Production: no port exposed to host
+    ports: []
+
+  redis:
+    # Production: no port exposed to host
+    ports: []
+
+volumes:
+  letsencrypt:

--- a/infra/traefik/dynamic.yml
+++ b/infra/traefik/dynamic.yml
@@ -32,9 +32,11 @@ http:
         referrerPolicy: "strict-origin-when-cross-origin"
         customResponseHeaders:
           X-Powered-By: ""
+          Server: ""
         stsSeconds: 31536000
         stsIncludeSubdomains: true
         stsPreload: true
+        contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'"
 
     # CORS middleware
     cors:
@@ -42,6 +44,7 @@ http:
         accessControlAllowOriginList:
           - "http://localhost:3000"
           - "http://localhost:8080"
+          - "https://fitnessai.app"
         accessControlAllowMethods:
           - GET
           - POST
@@ -60,8 +63,19 @@ http:
       buffering:
         maxRequestBodyBytes: 10485760
 
-# TLS configuration — uncomment for production
-# tls:
-#   options:
-#     default:
-#       minVersion: VersionTLS12
+    # HTTP to HTTPS redirect (used in production)
+    https-redirect:
+      redirectScheme:
+        scheme: https
+        permanent: true
+
+# TLS configuration for production
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      cipherSuites:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/infra/traefik/traefik.prod.yml
+++ b/infra/traefik/traefik.prod.yml
@@ -1,0 +1,54 @@
+# Traefik v3 static configuration — PRODUCTION
+# HTTPS with Let's Encrypt ACME certificate auto-renewal
+
+api:
+  dashboard: false  # Dashboard disabled in production
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+    http:
+      tls:
+        certResolver: letsencrypt
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: fitnessai
+  file:
+    filename: /etc/traefik/dynamic.yml
+    watch: true
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: admin@fitnessai.app
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+
+log:
+  level: WARN
+  format: json
+
+accessLog:
+  format: json
+  filters:
+    statusCodes:
+      - "400-599"
+  fields:
+    headers:
+      defaultMode: drop
+      names:
+        User-Agent: keep
+        X-Correlation-Id: keep
+        X-Forwarded-For: keep


### PR DESCRIPTION
## Summary
- Production Traefik config with Let's Encrypt ACME auto-renewal via HTTP challenge
- docker-compose.prod.yml override: all services on websecure entrypoint with TLS
- TLS 1.2+ minimum, modern cipher suites, HSTS preload, CSP headers
- Dashboard disabled, access logs filtered to errors only
- DB/Redis ports not exposed in production

## Test plan
- [x] Config files valid YAML syntax
- [x] Development docker-compose.yml unchanged (backward compatible)
- [x] Production usage: `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d`

Closes #33