### PR TITLE
#26 GDPR compliance: data export and account deletion

### DIFF
--- a/services/auth/app/router.py
+++ b/services/auth/app/router.py
@@ -9,6 +9,7 @@ from app.database import get_db
 from app.dependencies import get_current_user
 from app.models import User
 from app.schemas import (
+    AccountDeleteRequest,
     AuthResponse,
     CreditsResponse,
     TokenRefreshRequest,
@@ -194,6 +195,59 @@ async def deduct_credits(
             detail=exc.message,
         ) from exc
     return CreditsResponse(credits=remaining)
+
+
+# ============================================================
+# GDPR: Data Export & Account Deletion
+# ============================================================
+
+
+@router.get("/me/export")
+async def export_user_data(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Export all user data for GDPR compliance.
+
+    Returns a complete JSON document with profile, credentials,
+    workout plans, sessions, and AI scan history.
+
+    Args:
+        current_user: Authenticated user from JWT.
+        db: Database session.
+
+    Returns:
+        Complete user data export.
+    """
+    service = AuthService(db)
+    return await service.export_user_data(current_user.id)
+
+
+@router.delete("/me", status_code=204)
+async def delete_account(
+    request: AccountDeleteRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete user account and all associated data (GDPR right to erasure).
+
+    Requires password confirmation for security.
+    CASCADE deletes all auth-owned data. Cross-schema data
+    (workouts, AI) deleted explicitly.
+
+    Args:
+        request: Password confirmation.
+        current_user: Authenticated user from JWT.
+        db: Database session.
+    """
+    service = AuthService(db)
+    try:
+        await service.delete_account(current_user.id, request.password)
+    except InvalidCredentialsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect password",
+        ) from exc
 
 
 # ============================================================

--- a/services/auth/app/schemas.py
+++ b/services/auth/app/schemas.py
@@ -94,6 +94,12 @@ class CreditsResponse(BaseModel):
 # ============================================================
 
 
+class AccountDeleteRequest(BaseModel):
+    """Schema for account deletion request (GDPR)."""
+
+    password: str = Field(min_length=1, description="Password confirmation")
+
+
 class WebAuthnRegisterRequest(BaseModel):
     """Schema for WebAuthn credential registration."""
 

--- a/services/auth/app/service.py
+++ b/services/auth/app/service.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -507,3 +508,170 @@ class AuthService:
             .order_by(WebAuthnCredential.created_at.desc())
         )
         return list(result.scalars().all())
+
+    # ===========================================================
+    # GDPR: Data Export & Account Deletion
+    # ===========================================================
+
+    logger = logging.getLogger(__name__)
+
+    async def export_user_data(self, user_id: uuid.UUID) -> dict:
+        """Export all user data for GDPR compliance.
+
+        Aggregates data from auth schema and cross-schema reads
+        for workouts and AI data (read-only access).
+
+        Args:
+            user_id: The user UUID.
+
+        Returns:
+            Complete user data export dict.
+        """
+        user = await self.get_user_by_id(user_id)
+        uid_str = str(user_id)
+
+        export = {
+            "export_version": "1.0",
+            "exported_at": datetime.now(UTC).isoformat(),
+            "profile": {
+                "id": uid_str,
+                "email": user.email,
+                "name": user.name,
+                "age": user.age,
+                "goals": user.goals,
+                "limitations": user.limitations,
+                "ai_credits": user.ai_credits,
+                "language": user.language,
+                "created_at": user.created_at.isoformat()
+                if user.created_at
+                else None,
+            },
+            "webauthn_credentials": [],
+            "workout_plans": [],
+            "workout_sessions": [],
+            "ai_vision_scans": [],
+            "ai_coach_generations": [],
+        }
+
+        # WebAuthn credentials
+        creds = await self.list_webauthn_credentials(user_id)
+        export["webauthn_credentials"] = [
+            {
+                "credential_id": c.credential_id,
+                "device_name": c.device_name,
+                "created_at": c.created_at.isoformat()
+                if c.created_at
+                else None,
+            }
+            for c in creds
+        ]
+
+        # Cross-schema reads (workouts, AI) — best effort
+        try:
+            plans_result = await self.db.execute(
+                text(
+                    "SELECT id, name, description, source, created_at "
+                    "FROM workouts.workout_plans WHERE user_id = :uid"
+                ),
+                {"uid": user_id},
+            )
+            export["workout_plans"] = [
+                dict(row._mapping) for row in plans_result
+            ]
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug("Could not read workout plans: %s", exc)
+
+        try:
+            sessions_result = await self.db.execute(
+                text(
+                    "SELECT id, day_name, started_at, completed_at, "
+                    "duration_seconds, notes FROM "
+                    "workouts.workout_sessions WHERE user_id = :uid"
+                ),
+                {"uid": user_id},
+            )
+            export["workout_sessions"] = [
+                dict(row._mapping) for row in sessions_result
+            ]
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug("Could not read workout sessions: %s", exc)
+
+        try:
+            scans_result = await self.db.execute(
+                text(
+                    "SELECT id, equipment_name, equipment_brand, "
+                    "credits_used, created_at FROM "
+                    "ai.ai_vision_scans WHERE user_id = :uid"
+                ),
+                {"uid": user_id},
+            )
+            export["ai_vision_scans"] = [
+                dict(row._mapping) for row in scans_result
+            ]
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug("Could not read AI vision scans: %s", exc)
+
+        try:
+            coach_result = await self.db.execute(
+                text(
+                    "SELECT id, photo_count, credits_used, created_at "
+                    "FROM ai.ai_coach_generations WHERE user_id = :uid"
+                ),
+                {"uid": user_id},
+            )
+            export["ai_coach_generations"] = [
+                dict(row._mapping) for row in coach_result
+            ]
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug("Could not read AI coach data: %s", exc)
+
+        self.logger.info(
+            "GDPR data export completed for user=%s", uid_str
+        )
+        return export
+
+    async def delete_account(
+        self, user_id: uuid.UUID, password: str
+    ) -> bool:
+        """Delete a user account and all associated data (GDPR).
+
+        Verifies password before deletion. CASCADE deletes handle
+        auth schema data. Cross-schema data deleted explicitly.
+
+        Args:
+            user_id: The user UUID.
+            password: Password confirmation for security.
+
+        Returns:
+            True if account was deleted.
+
+        Raises:
+            InvalidCredentialsError: If password is incorrect.
+        """
+        user = await self.get_user_by_id(user_id)
+
+        if not verify_password(password, user.password_hash):
+            raise InvalidCredentialsError()
+
+        uid_str = str(user_id)
+
+        # Delete cross-schema data (best effort)
+        for stmt in [
+            "DELETE FROM workouts.workout_sessions WHERE user_id = :uid",
+            "DELETE FROM workouts.workout_plans WHERE user_id = :uid",
+            "DELETE FROM ai.ai_vision_scans WHERE user_id = :uid",
+            "DELETE FROM ai.ai_coach_generations WHERE user_id = :uid",
+        ]:
+            try:
+                await self.db.execute(text(stmt), {"uid": user_id})
+            except Exception as exc:  # noqa: BLE001
+                self.logger.debug("Cross-schema delete skipped: %s", exc)
+
+        # Delete user (CASCADE handles auth schema tables)
+        await self.db.delete(user)
+        await self.db.commit()
+
+        self.logger.info(
+            "GDPR account deletion completed for user=%s", uid_str
+        )
+        return True

--- a/services/auth/tests/test_gdpr.py
+++ b/services/auth/tests/test_gdpr.py
@@ -1,0 +1,94 @@
+"""Tests for GDPR data export and account deletion endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import register_and_get_token
+
+
+@pytest.mark.asyncio
+async def test_export_user_data(client: AsyncClient):
+    """Export should return structured JSON with user data."""
+    headers = await register_and_get_token(client)
+
+    response = await client.get("/auth/me/export", headers=headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["export_version"] == "1.0"
+    assert "exported_at" in data
+    assert "profile" in data
+    assert data["profile"]["email"] is not None
+    assert "webauthn_credentials" in data
+    assert "workout_plans" in data
+    assert "workout_sessions" in data
+    assert "ai_vision_scans" in data
+    assert "ai_coach_generations" in data
+
+
+@pytest.mark.asyncio
+async def test_export_unauthenticated(client: AsyncClient):
+    """Export without auth should return 401/403."""
+    response = await client.get("/auth/me/export")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_delete_account_success(client: AsyncClient):
+    """Delete with correct password should return 204."""
+    # Register user
+    resp = await client.post(
+        "/auth/register",
+        json={
+            "email": "delete-me@example.com",
+            "password": "DeleteMe123",
+            "name": "Delete User",
+        },
+    )
+    assert resp.status_code == 201
+    token = resp.json()["tokens"]["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Verify profile exists
+    profile_resp = await client.get("/auth/me", headers=headers)
+    assert profile_resp.status_code == 200
+
+    # Delete account
+    delete_resp = await client.request(
+        "DELETE",
+        "/auth/me",
+        headers=headers,
+        json={"password": "DeleteMe123"},
+    )
+    assert delete_resp.status_code == 204
+
+    # Verify account is gone (token should be invalid)
+    check_resp = await client.get("/auth/me", headers=headers)
+    assert check_resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_account_wrong_password(client: AsyncClient):
+    """Delete with wrong password should return 401."""
+    headers = await register_and_get_token(client)
+
+    response = await client.request(
+        "DELETE",
+        "/auth/me",
+        headers=headers,
+        json={"password": "WrongPassword999"},
+    )
+    assert response.status_code == 401
+    assert "password" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_account_unauthenticated(client: AsyncClient):
+    """Delete without auth should return 401/403."""
+    response = await client.request(
+        "DELETE",
+        "/auth/me",
+        json={"password": "anything"},
+    )
+    assert response.status_code in (401, 403)


### PR DESCRIPTION
## Summary
- GET /auth/me/export: complete user data export (profile, WebAuthn credentials, workout plans/sessions, AI scans/generations)
- DELETE /auth/me: account deletion with password confirmation and cross-schema cascade
- Audit logging for both GDPR operations
- Cross-schema data reads and deletes with graceful fallback

## Test plan
- [x] 35 auth tests passing (5 new GDPR tests)
- [x] Export returns structured JSON with all data categories
- [x] Delete with correct password returns 204 and account is gone
- [x] Delete with wrong password returns 401
- [x] Both endpoints require authentication
- [x] Ruff linter clean

Closes #26