### PR TITLE
Dominio fitness-ai.caporossi.net + Face ID (WebAuthn)

### DIFF
--- a/app/lib/core/auth/webauthn.dart
+++ b/app/lib/core/auth/webauthn.dart
@@ -1,0 +1,5 @@
+/// Cross-platform WebAuthn facade.
+///
+/// On web it binds to `web/webauthn.js` via dart:js_interop; on other platforms
+/// it falls back to a stub that reports unsupported.
+export 'webauthn_stub.dart' if (dart.library.js_interop) 'webauthn_web.dart';

--- a/app/lib/core/auth/webauthn_stub.dart
+++ b/app/lib/core/auth/webauthn_stub.dart
@@ -1,0 +1,9 @@
+/// Non-web fallback: WebAuthn (Face ID via browser) is only available on web.
+
+bool webauthnSupported() => false;
+
+Future<Map<String, dynamic>> webauthnRegister(Map<String, dynamic> options) =>
+    throw UnsupportedError('WebAuthn is only available on the web build');
+
+Future<Map<String, dynamic>> webauthnAuthenticate(Map<String, dynamic> options) =>
+    throw UnsupportedError('WebAuthn is only available on the web build');

--- a/app/lib/core/auth/webauthn_web.dart
+++ b/app/lib/core/auth/webauthn_web.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'dart:js_interop';
+
+@JS('fitnessWebAuthnSupported')
+external JSBoolean _supported();
+
+@JS('fitnessWebAuthnRegister')
+external JSPromise<JSString> _register(JSString optionsJson);
+
+@JS('fitnessWebAuthnAuthenticate')
+external JSPromise<JSString> _authenticate(JSString optionsJson);
+
+/// Whether the browser exposes a usable WebAuthn platform authenticator.
+bool webauthnSupported() {
+  try {
+    return _supported().toDart;
+  } catch (_) {
+    return false;
+  }
+}
+
+/// Run the registration ceremony (creates a passkey bound to the device).
+/// [options] must contain: challenge, rp_id, rp_name, user_id, user_name.
+/// Returns: { credential_id, public_key }.
+Future<Map<String, dynamic>> webauthnRegister(Map<String, dynamic> options) async {
+  final res = await _register(jsonEncode(options).toJS).toDart;
+  return jsonDecode(res.toDart) as Map<String, dynamic>;
+}
+
+/// Run the authentication ceremony (Face ID / biometric unlock).
+/// [options] must contain: rp_id, credential_id.
+/// Returns: { credential_id, authenticator_data, client_data_json, signature }.
+Future<Map<String, dynamic>> webauthnAuthenticate(Map<String, dynamic> options) async {
+  final res = await _authenticate(jsonEncode(options).toJS).toDart;
+  return jsonDecode(res.toDart) as Map<String, dynamic>;
+}

--- a/app/lib/core/constants/api_constants.dart
+++ b/app/lib/core/constants/api_constants.dart
@@ -8,7 +8,7 @@ class ApiConstants {
   /// Android emulator uses 10.0.2.2 for host localhost.
   /// iOS simulator uses localhost directly.
   static const String devBaseUrl = 'http://10.0.2.2';
-  static const String prodBaseUrl = 'https://54-170-27-110.sslip.io';
+  static const String prodBaseUrl = 'https://fitness-ai.caporossi.net';
 
   // Auth endpoints
   static const String authRegister = '/auth/register';
@@ -16,6 +16,9 @@ class ApiConstants {
   static const String authRefresh = '/auth/refresh';
   static const String authMe = '/auth/me';
   static const String authCredits = '/auth/credits';
+  static const String authWebauthnRegisterBegin = '/auth/webauthn/register/begin';
+  static const String authWebauthnRegisterComplete = '/auth/webauthn/register/complete';
+  static const String authWebauthnLogin = '/auth/webauthn/login';
 
   // Workout endpoints
   static const String workoutPlans = '/workouts/plans';

--- a/app/lib/core/network/api_client.dart
+++ b/app/lib/core/network/api_client.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fitness_ai/core/constants/api_constants.dart';
@@ -73,5 +74,8 @@ class ApiClient {
 /// Provider for the API client singleton.
 final apiClientProvider = Provider<ApiClient>((ref) {
   final tokenStorage = ref.watch(tokenStorageProvider);
-  return ApiClient(tokenStorage: tokenStorage, baseUrl: ApiConstants.prodBaseUrl);
+  // On web, call the same origin the app is served from (works on any domain
+  // and keeps requests same-origin, which also satisfies WebAuthn RP ID).
+  final base = kIsWeb ? Uri.base.origin : ApiConstants.prodBaseUrl;
+  return ApiClient(tokenStorage: tokenStorage, baseUrl: base);
 });

--- a/app/lib/features/auth/data/auth_repository.dart
+++ b/app/lib/features/auth/data/auth_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:fitness_ai/core/auth/webauthn.dart' as webauthn;
 import 'package:fitness_ai/core/constants/api_constants.dart';
 import 'package:fitness_ai/core/network/api_client.dart';
 import 'package:fitness_ai/core/network/api_exception.dart';
@@ -119,6 +120,72 @@ class AuthRepository {
 
   void _cacheUser(User user) {
     HiveStorage.user.put('profile', user.toJson());
+  }
+
+  // ============================================================
+  // WebAuthn (Face ID / passkey)
+  // ============================================================
+
+  static const _webauthnCredKey = 'webauthn_credential_id';
+
+  /// The Face ID credential registered on THIS device, if any.
+  String? get storedWebAuthnCredentialId {
+    final v = HiveStorage.user.get(_webauthnCredKey);
+    return (v is String && v.isNotEmpty) ? v : null;
+  }
+
+  /// Whether the current platform/browser supports WebAuthn.
+  bool get webauthnSupported => webauthn.webauthnSupported();
+
+  /// Register a passkey (Face ID) on this device. Requires an active session.
+  Future<void> enableWebAuthn() async {
+    try {
+      final begin = await apiClient.post(ApiConstants.authWebauthnRegisterBegin);
+      final opts = Map<String, dynamic>.from(begin.data as Map);
+      final cred = await webauthn.webauthnRegister(opts);
+      await apiClient.post(
+        ApiConstants.authWebauthnRegisterComplete,
+        data: {
+          'credential_id': cred['credential_id'],
+          'public_key': cred['public_key'],
+          'device_name': 'Browser PWA',
+        },
+      );
+      await HiveStorage.user.put(_webauthnCredKey, cred['credential_id']);
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  /// Log in using the device's registered passkey (Face ID).
+  Future<User> loginWithWebAuthn() async {
+    final credId = storedWebAuthnCredentialId;
+    if (credId == null) {
+      throw const ApiException(
+        message: 'Face ID non configurato su questo dispositivo',
+      );
+    }
+    try {
+      final assertion = await webauthn.webauthnAuthenticate({
+        'rp_id': Uri.base.host,
+        'credential_id': credId,
+      });
+      final response = await apiClient.post(
+        ApiConstants.authWebauthnLogin,
+        data: assertion,
+      );
+      final data = response.data as Map<String, dynamic>;
+      final tokens = data['tokens'] as Map<String, dynamic>;
+      await tokenStorage.saveTokens(
+        accessToken: tokens['access_token'] as String,
+        refreshToken: tokens['refresh_token'] as String,
+      );
+      final user = User.fromJson(data['user'] as Map<String, dynamic>);
+      _cacheUser(user);
+      return user;
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
   }
 }
 

--- a/app/lib/features/auth/presentation/auth_notifier.dart
+++ b/app/lib/features/auth/presentation/auth_notifier.dart
@@ -88,6 +88,32 @@ class AuthNotifier extends Notifier<AuthState> {
     await _repo.logout();
     state = const AuthState.unauthenticated();
   }
+
+  // ============================================================
+  // WebAuthn (Face ID)
+  // ============================================================
+
+  /// Whether the browser supports Face ID / passkeys.
+  bool get webauthnSupported => _repo.webauthnSupported;
+
+  /// Whether THIS device already has Face ID enabled.
+  bool get hasWebAuthnCredential => _repo.storedWebAuthnCredentialId != null;
+
+  /// Register Face ID on this device (must be logged in). Throws on failure.
+  Future<void> enableWebAuthn() => _repo.enableWebAuthn();
+
+  /// Authenticate with Face ID.
+  Future<void> loginWebAuthn() async {
+    state = const AuthState.loading();
+    try {
+      final user = await _repo.loginWithWebAuthn();
+      state = AuthState.authenticated(user);
+    } on ApiException catch (e) {
+      state = AuthState.error(e.toString());
+    } catch (e) {
+      state = AuthState.error(e.toString());
+    }
+  }
 }
 
 /// Global auth state provider.

--- a/app/lib/features/auth/presentation/login_screen.dart
+++ b/app/lib/features/auth/presentation/login_screen.dart
@@ -42,9 +42,17 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     if (mounted) setState(() => _isSubmitting = false);
   }
 
+  Future<void> _faceIdLogin() async {
+    setState(() => _isSubmitting = true);
+    await ref.read(authNotifierProvider.notifier).loginWebAuthn();
+    if (mounted) setState(() => _isSubmitting = false);
+  }
+
   @override
   Widget build(BuildContext context) {
     final l = S.of(context)!;
+    final auth = ref.read(authNotifierProvider.notifier);
+    final showFaceId = auth.webauthnSupported && auth.hasWebAuthnCredential;
 
     // Show error snackbar when auth fails
     ref.listen<AuthState>(authNotifierProvider, (prev, next) {
@@ -132,6 +140,19 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   enabled: !_isSubmitting,
                   icon: Icons.login,
                 ),
+                if (showFaceId) ...[
+                  const SizedBox(height: AppSpacing.md),
+                  OutlinedButton.icon(
+                    onPressed: _isSubmitting ? null : _faceIdLogin,
+                    icon: const Icon(Icons.face_retouching_natural),
+                    label: const Text('Accedi con Face ID'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: AppColors.primary,
+                      side: const BorderSide(color: AppColors.primary),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                    ),
+                  ),
+                ],
                 const SizedBox(height: AppSpacing.md),
                 TextButton(
                   onPressed: () => context.go('/register'),

--- a/app/lib/features/profile/presentation/profile_screen.dart
+++ b/app/lib/features/profile/presentation/profile_screen.dart
@@ -104,6 +104,16 @@ class ProfileScreen extends ConsumerWidget {
             label: 'Lingua',
             onTap: () {},
           ),
+          if (ref.read(authNotifierProvider.notifier).webauthnSupported)
+            _buildMenuItem(
+              context,
+              icon: Icons.face_retouching_natural,
+              label:
+                  ref.read(authNotifierProvider.notifier).hasWebAuthnCredential
+                      ? 'Face ID attivo'
+                      : 'Abilita Face ID',
+              onTap: () => _enableFaceId(context, ref),
+            ),
           const Spacer(),
           GlowButton(
             label: 'Esci',
@@ -117,6 +127,32 @@ class ProfileScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  Future<void> _enableFaceId(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final notifier = ref.read(authNotifierProvider.notifier);
+    if (notifier.hasWebAuthnCredential) {
+      messenger.showSnackBar(const SnackBar(
+        content: Text('Face ID è già attivo su questo dispositivo'),
+      ));
+      return;
+    }
+    messenger.showSnackBar(const SnackBar(
+      content: Text('Conferma con il volto / impronta...'),
+    ));
+    try {
+      await notifier.enableWebAuthn();
+      messenger.showSnackBar(const SnackBar(
+        content: Text('Face ID attivato! Ora puoi accedere col volto.'),
+        backgroundColor: AppColors.success,
+      ));
+    } catch (e) {
+      messenger.showSnackBar(SnackBar(
+        content: Text('Face ID non attivato: $e'),
+        backgroundColor: AppColors.error,
+      ));
+    }
   }
 
   Widget _buildMenuItem(

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -29,8 +29,10 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>fitness_ai</title>
+  <title>FitnessAI</title>
   <link rel="manifest" href="manifest.json">
+  <!-- WebAuthn (Face ID / passkey) helper -->
+  <script src="webauthn.js"></script>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>

--- a/app/web/webauthn.js
+++ b/app/web/webauthn.js
@@ -1,0 +1,79 @@
+// WebAuthn (Face ID / passkey) helper for the FitnessAI PWA.
+// Exposes three globals called from Dart via dart:js_interop. Keeps all the
+// ArrayBuffer <-> base64url handling here (standard, reliable browser code).
+
+function _b64urlToBuf(s) {
+  s = s.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = '='.repeat((4 - (s.length % 4)) % 4);
+  const bin = atob(s + pad);
+  const b = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) b[i] = bin.charCodeAt(i);
+  return b.buffer;
+}
+
+function _bufToB64url(buf) {
+  const b = new Uint8Array(buf);
+  let s = '';
+  for (let i = 0; i < b.length; i++) s += String.fromCharCode(b[i]);
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+window.fitnessWebAuthnSupported = function () {
+  return !!(window.PublicKeyCredential && navigator.credentials && navigator.credentials.create);
+};
+
+// options: { challenge, rp_id, rp_name, user_id, user_name, timeout }
+window.fitnessWebAuthnRegister = async function (optionsJson) {
+  const o = JSON.parse(optionsJson);
+  const publicKey = {
+    challenge: _b64urlToBuf(o.challenge),
+    rp: { id: o.rp_id, name: o.rp_name || 'FitnessAI' },
+    user: {
+      id: new TextEncoder().encode(o.user_id),
+      name: o.user_name,
+      displayName: o.user_name,
+    },
+    pubKeyCredParams: [
+      { type: 'public-key', alg: -7 },
+      { type: 'public-key', alg: -257 },
+    ],
+    authenticatorSelection: {
+      authenticatorAttachment: 'platform',
+      userVerification: 'required',
+      residentKey: 'preferred',
+    },
+    timeout: o.timeout || 60000,
+    attestation: 'none',
+  };
+  const cred = await navigator.credentials.create({ publicKey });
+  const resp = cred.response;
+  let pub = '';
+  try {
+    if (resp.getPublicKey) {
+      const pk = resp.getPublicKey();
+      if (pk) pub = _bufToB64url(pk);
+    }
+  } catch (e) { /* ignore */ }
+  if (!pub) pub = _bufToB64url(resp.attestationObject);
+  return JSON.stringify({ credential_id: cred.id, public_key: pub });
+};
+
+// options: { rp_id, credential_id, timeout }
+window.fitnessWebAuthnAuthenticate = async function (optionsJson) {
+  const o = JSON.parse(optionsJson);
+  const publicKey = {
+    challenge: crypto.getRandomValues(new Uint8Array(32)).buffer,
+    rpId: o.rp_id,
+    allowCredentials: [{ type: 'public-key', id: _b64urlToBuf(o.credential_id) }],
+    userVerification: 'required',
+    timeout: o.timeout || 60000,
+  };
+  const assertion = await navigator.credentials.get({ publicKey });
+  const r = assertion.response;
+  return JSON.stringify({
+    credential_id: assertion.id,
+    authenticator_data: _bufToB64url(r.authenticatorData),
+    client_data_json: _bufToB64url(r.clientDataJSON),
+    signature: _bufToB64url(r.signature),
+  });
+};

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,7 +26,7 @@ services:
   auth:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.auth.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/auth`)"
+      - "traefik.http.routers.auth.rule=(Host(`${DOMAIN:-fitnessai.app}`) || Host(`54-170-27-110.sslip.io`)) && PathPrefix(`/auth`)"
       - "traefik.http.routers.auth.entrypoints=websecure"
       - "traefik.http.routers.auth.tls=true"
       - "traefik.http.routers.auth.tls.certresolver=letsencrypt"
@@ -36,7 +36,7 @@ services:
   workouts:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.workouts.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/workouts`)"
+      - "traefik.http.routers.workouts.rule=(Host(`${DOMAIN:-fitnessai.app}`) || Host(`54-170-27-110.sslip.io`)) && PathPrefix(`/workouts`)"
       - "traefik.http.routers.workouts.entrypoints=websecure"
       - "traefik.http.routers.workouts.tls=true"
       - "traefik.http.routers.workouts.tls.certresolver=letsencrypt"
@@ -46,7 +46,7 @@ services:
   ai:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.ai.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/ai`)"
+      - "traefik.http.routers.ai.rule=(Host(`${DOMAIN:-fitnessai.app}`) || Host(`54-170-27-110.sslip.io`)) && PathPrefix(`/ai`)"
       - "traefik.http.routers.ai.entrypoints=websecure"
       - "traefik.http.routers.ai.tls=true"
       - "traefik.http.routers.ai.tls.certresolver=letsencrypt"
@@ -56,7 +56,7 @@ services:
   analytics:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.analytics.rule=Host(`${DOMAIN:-fitnessai.app}`) && PathPrefix(`/analytics`)"
+      - "traefik.http.routers.analytics.rule=(Host(`${DOMAIN:-fitnessai.app}`) || Host(`54-170-27-110.sslip.io`)) && PathPrefix(`/analytics`)"
       - "traefik.http.routers.analytics.entrypoints=websecure"
       - "traefik.http.routers.analytics.tls=true"
       - "traefik.http.routers.analytics.tls.certresolver=letsencrypt"
@@ -66,7 +66,7 @@ services:
   web:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.web.rule=Host(`${DOMAIN:-fitnessai.app}`)"
+      - "traefik.http.routers.web.rule=(Host(`${DOMAIN:-fitnessai.app}`) || Host(`54-170-27-110.sslip.io`))"
       - "traefik.http.routers.web.entrypoints=websecure"
       - "traefik.http.routers.web.tls=true"
       - "traefik.http.routers.web.tls.certresolver=letsencrypt"
@@ -92,7 +92,7 @@ services:
       - ./infra/nginx/pwa.conf:/etc/nginx/conf.d/default.conf:ro
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.pwa.rule=Host(`${DOMAIN:-localhost}`)"
+      - "traefik.http.routers.pwa.rule=(Host(`${DOMAIN:-localhost}`) || Host(`54-170-27-110.sslip.io`))"
       - "traefik.http.routers.pwa.entrypoints=websecure"
       - "traefik.http.routers.pwa.tls=true"
       - "traefik.http.routers.pwa.tls.certresolver=letsencrypt"

--- a/services/auth/app/config.py
+++ b/services/auth/app/config.py
@@ -27,6 +27,10 @@ class Settings(BaseSettings):
     service_name: str = "auth"
     service_port: int = 8001
 
+    # WebAuthn (Face ID / passkeys) — RP ID must match the serving domain
+    webauthn_rp_id: str = "fitness-ai.caporossi.net"
+    webauthn_rp_name: str = "FitnessAI"
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/services/auth/app/service.py
+++ b/services/auth/app/service.py
@@ -327,8 +327,8 @@ class AuthService:
 
         return {
             "challenge": challenge,
-            "rp_id": "fitnessai.app",
-            "rp_name": "FitnessAI",
+            "rp_id": settings.webauthn_rp_id,
+            "rp_name": settings.webauthn_rp_name,
             "user_id": str(user.id),
             "user_name": user.email,
             "timeout": 60000,

--- a/services/auth/tests/test_webauthn.py
+++ b/services/auth/tests/test_webauthn.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
+from app.config import settings
 from tests.conftest import register_and_get_token
 
 
@@ -20,8 +21,8 @@ async def test_webauthn_register_begin(client: AsyncClient):
     assert response.status_code == 200
     data = response.json()
     assert "challenge" in data
-    assert data["rp_id"] == "fitnessai.app"
-    assert data["rp_name"] == "FitnessAI"
+    assert data["rp_id"] == settings.webauthn_rp_id
+    assert data["rp_name"] == settings.webauthn_rp_name
     assert data["timeout"] == 60000
     assert "user_id" in data
     assert "user_name" in data


### PR DESCRIPTION
## Dominio
- Traefik dual-host: fitness-ai.caporossi.net (nuovo cert Let's Encrypt) + sslip durante la transizione. **Verificato live**: HTTPS valido, login/plans/sessions 200 same-origin.
- App web usa l'origin corrente come base URL (no CORS, RP ID coerente).

## Face ID (WebAuthn)
- Backend: RP ID configurabile = dominio (era hardcoded fitnessai.app).
- Client: web/webauthn.js (navigator.credentials) + dart:js_interop + facade cross-platform.
- UI additiva: Profilo 'Abilita Face ID', Login 'Accedi con Face ID'. Password resta fallback.
- **Verificato**: build OK, JS helper caricato (supported=true), password login senza regressioni, Profilo mostra l'opzione. La cerimonia biometrica va testata su device reale.

⚠️ La verifica WebAuthn lato backend è semplificata (challenge-flow, non verifica la firma crittograficamente) — da hardennare come step successivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)