### PR TITLE
Profilo: dati reali utente + Impostazioni/Esporta/Lingua funzionanti

### DIFF
--- a/app/lib/core/auth/webauthn_stub.dart
+++ b/app/lib/core/auth/webauthn_stub.dart
@@ -7,3 +7,7 @@ Future<Map<String, dynamic>> webauthnRegister(Map<String, dynamic> options) =>
 
 Future<Map<String, dynamic>> webauthnAuthenticate(Map<String, dynamic> options) =>
     throw UnsupportedError('WebAuthn is only available on the web build');
+
+void downloadFile(String filename, String text) {
+  throw UnsupportedError('File download is only available on the web build');
+}

--- a/app/lib/core/auth/webauthn_web.dart
+++ b/app/lib/core/auth/webauthn_web.dart
@@ -10,6 +10,14 @@ external JSPromise<JSString> _register(JSString optionsJson);
 @JS('fitnessWebAuthnAuthenticate')
 external JSPromise<JSString> _authenticate(JSString optionsJson);
 
+@JS('fitnessDownload')
+external void _download(JSString filename, JSString text);
+
+/// Trigger a browser download of [text] as [filename].
+void downloadFile(String filename, String text) {
+  _download(filename.toJS, text.toJS);
+}
+
 /// Whether the browser exposes a usable WebAuthn platform authenticator.
 bool webauthnSupported() {
   try {

--- a/app/lib/core/constants/api_constants.dart
+++ b/app/lib/core/constants/api_constants.dart
@@ -15,6 +15,7 @@ class ApiConstants {
   static const String authLogin = '/auth/login';
   static const String authRefresh = '/auth/refresh';
   static const String authMe = '/auth/me';
+  static const String authMeExport = '/auth/me/export';
   static const String authCredits = '/auth/credits';
   static const String authWebauthnRegisterBegin = '/auth/webauthn/register/begin';
   static const String authWebauthnRegisterComplete = '/auth/webauthn/register/complete';

--- a/app/lib/core/locale_provider.dart
+++ b/app/lib/core/locale_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fitness_ai/core/storage/hive_storage.dart';
+
+/// App locale, persisted in Hive. Defaults to Italian.
+class LocaleNotifier extends Notifier<Locale> {
+  static const _key = 'app_locale';
+
+  @override
+  Locale build() {
+    final code = HiveStorage.user.get(_key);
+    return Locale((code is String && code.isNotEmpty) ? code : 'it');
+  }
+
+  /// Change the app language ('it' or 'en') and persist it.
+  void setLanguage(String code) {
+    HiveStorage.user.put(_key, code);
+    state = Locale(code);
+  }
+}
+
+final localeProvider = NotifierProvider<LocaleNotifier, Locale>(LocaleNotifier.new);

--- a/app/lib/features/auth/data/auth_repository.dart
+++ b/app/lib/features/auth/data/auth_repository.dart
@@ -102,6 +102,16 @@ class AuthRepository {
     }
   }
 
+  /// Export all user data (GDPR) as a JSON-serialisable map.
+  Future<Map<String, dynamic>> exportData() async {
+    try {
+      final response = await apiClient.get(ApiConstants.authMeExport);
+      return Map<String, dynamic>.from(response.data as Map);
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
   /// Get cached user from Hive (for offline).
   User? getCachedUser() {
     final data = HiveStorage.user.get('profile');

--- a/app/lib/features/auth/presentation/auth_notifier.dart
+++ b/app/lib/features/auth/presentation/auth_notifier.dart
@@ -99,6 +99,9 @@ class AuthNotifier extends Notifier<AuthState> {
   /// Whether THIS device already has Face ID enabled.
   bool get hasWebAuthnCredential => _repo.storedWebAuthnCredentialId != null;
 
+  /// Export all user data (GDPR) as a JSON-serialisable map.
+  Future<Map<String, dynamic>> exportData() => _repo.exportData();
+
   /// Register Face ID on this device (must be logged in). Throws on failure.
   Future<void> enableWebAuthn() => _repo.enableWebAuthn();
 

--- a/app/lib/features/profile/presentation/profile_screen.dart
+++ b/app/lib/features/profile/presentation/profile_screen.dart
@@ -1,10 +1,15 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:fitness_ai/core/auth/webauthn.dart' as webauthn;
+import 'package:fitness_ai/core/locale_provider.dart';
 import 'package:fitness_ai/core/theme/app_colors.dart';
 import 'package:fitness_ai/core/theme/app_spacing.dart';
 import 'package:fitness_ai/core/widgets/widgets.dart';
 import 'package:fitness_ai/features/auth/domain/auth_state.dart';
+import 'package:fitness_ai/features/auth/domain/user.dart';
 import 'package:fitness_ai/features/auth/presentation/auth_notifier.dart';
 
 /// User profile screen with account info and settings.
@@ -14,6 +19,7 @@ class ProfileScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authState = ref.watch(authNotifierProvider);
+    final user = authState is AuthAuthenticated ? authState.user : null;
 
     return Scaffold(
       body: SafeArea(
@@ -23,13 +29,9 @@ class ProfileScreen extends ConsumerWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const SizedBox(height: AppSpacing.md),
-              Text(
-                'Profilo',
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
+              Text('Profilo', style: Theme.of(context).textTheme.headlineMedium),
               const SizedBox(height: AppSpacing.lg),
-              if (authState case AuthState())
-                _buildProfileContent(context, ref, authState),
+              Expanded(child: _content(context, ref, user)),
             ],
           ),
         ),
@@ -37,93 +39,169 @@ class ProfileScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildProfileContent(
-    BuildContext context,
-    WidgetRef ref,
-    AuthState authState,
-  ) {
-    // Extract user if authenticated - for now show placeholder
-    return Expanded(
-      child: Column(
-        children: [
-          GlassmorphismCard(
-            child: Row(
-              children: [
-                CircleAvatar(
-                  radius: 30,
-                  backgroundColor: AppColors.primary.withValues(alpha: 0.2),
-                  child: const Icon(
-                    Icons.person,
-                    size: 30,
-                    color: AppColors.primary,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.md),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Utente',
+  Widget _content(BuildContext context, WidgetRef ref, User? user) {
+    final notifier = ref.read(authNotifierProvider.notifier);
+    final displayName = (user?.name?.trim().isNotEmpty ?? false)
+        ? user!.name!
+        : (user?.email ?? 'Utente');
+
+    return Column(
+      children: [
+        GlassmorphismCard(
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 30,
+                backgroundColor: AppColors.primary.withValues(alpha: 0.2),
+                child: const Icon(Icons.person, size: 30, color: AppColors.primary),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(displayName,
                         style: Theme.of(context).textTheme.titleMedium,
-                      ),
-                      const SizedBox(height: AppSpacing.xs),
-                      Row(
-                        children: [
-                          const Icon(Icons.auto_awesome,
-                              size: 16, color: AppColors.warning),
-                          const SizedBox(width: AppSpacing.xs),
-                          Text(
-                            '0 crediti AI',
-                            style: Theme.of(context).textTheme.bodyMedium,
-                          ),
-                        ],
-                      ),
+                        overflow: TextOverflow.ellipsis),
+                    if (user?.email != null && displayName != user!.email) ...[
+                      const SizedBox(height: 2),
+                      Text(user.email,
+                          style: Theme.of(context).textTheme.bodySmall,
+                          overflow: TextOverflow.ellipsis),
                     ],
-                  ),
+                    const SizedBox(height: AppSpacing.xs),
+                    Row(
+                      children: [
+                        const Icon(Icons.auto_awesome,
+                            size: 16, color: AppColors.warning),
+                        const SizedBox(width: AppSpacing.xs),
+                        Text('${user?.aiCredits ?? 0} crediti AI',
+                            style: Theme.of(context).textTheme.bodyMedium),
+                      ],
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-          const SizedBox(height: AppSpacing.lg),
-          _buildMenuItem(
-            context,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        _menuItem(context,
             icon: Icons.settings,
             label: 'Impostazioni',
-            onTap: () {},
-          ),
-          _buildMenuItem(
-            context,
+            onTap: () => _showSettings(context, user)),
+        _menuItem(context,
             icon: Icons.download,
             label: 'Esporta Dati',
-            onTap: () {},
-          ),
-          _buildMenuItem(
-            context,
+            onTap: () => _exportData(context, ref)),
+        _menuItem(context,
             icon: Icons.language,
-            label: 'Lingua',
-            onTap: () {},
-          ),
-          if (ref.read(authNotifierProvider.notifier).webauthnSupported)
-            _buildMenuItem(
-              context,
+            label: 'Lingua (${ref.watch(localeProvider).languageCode.toUpperCase()})',
+            onTap: () => _showLanguage(context, ref)),
+        if (notifier.webauthnSupported)
+          _menuItem(context,
               icon: Icons.face_retouching_natural,
-              label:
-                  ref.read(authNotifierProvider.notifier).hasWebAuthnCredential
-                      ? 'Face ID attivo'
-                      : 'Abilita Face ID',
-              onTap: () => _enableFaceId(context, ref),
-            ),
-          const Spacer(),
-          GlowButton(
-            label: 'Esci',
-            onPressed: () {
-              ref.read(authNotifierProvider.notifier).logout();
-            },
-            color: AppColors.error,
-            icon: Icons.logout,
+              label: notifier.hasWebAuthnCredential
+                  ? 'Face ID attivo'
+                  : 'Abilita Face ID',
+              onTap: () => _enableFaceId(context, ref)),
+        const Spacer(),
+        GlowButton(
+          label: 'Esci',
+          onPressed: () => ref.read(authNotifierProvider.notifier).logout(),
+          color: AppColors.error,
+          icon: Icons.logout,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+      ],
+    );
+  }
+
+  // -------- Actions --------
+
+  void _showSettings(BuildContext context, User? user) {
+    String d(DateTime? x) =>
+        x == null ? '-' : '${x.day}/${x.month}/${x.year}';
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.bgSecondary,
+        title: const Text('Account'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _infoRow('Email', user?.email ?? '-'),
+            _infoRow('Crediti AI', '${user?.aiCredits ?? 0}'),
+            _infoRow('Lingua', (user?.language ?? 'it').toUpperCase()),
+            _infoRow('Iscritto dal', d(user?.createdAt)),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Chiudi'),
           ),
-          const SizedBox(height: AppSpacing.lg),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _exportData(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+        const SnackBar(content: Text('Esportazione in corso...')));
+    try {
+      final data = await ref.read(authNotifierProvider.notifier).exportData();
+      webauthn.downloadFile(
+        'fitnessai-export.json',
+        const JsonEncoder.withIndent('  ').convert(data),
+      );
+      messenger.showSnackBar(const SnackBar(
+        content: Text('Dati esportati — download avviato'),
+        backgroundColor: AppColors.success,
+      ));
+    } catch (e) {
+      messenger.showSnackBar(SnackBar(
+        content: Text('Export non riuscito: $e'),
+        backgroundColor: AppColors.error,
+      ));
+    }
+  }
+
+  void _showLanguage(BuildContext context, WidgetRef ref) {
+    final current = ref.read(localeProvider).languageCode;
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        backgroundColor: AppColors.bgSecondary,
+        title: const Text('Lingua'),
+        children: [
+          _langTile(ctx, ref, 'it', 'Italiano', current),
+          _langTile(ctx, ref, 'en', 'English', current),
+        ],
+      ),
+    );
+  }
+
+  Widget _langTile(
+      BuildContext ctx, WidgetRef ref, String code, String label, String current) {
+    return SimpleDialogOption(
+      onPressed: () {
+        ref.read(localeProvider.notifier).setLanguage(code);
+        Navigator.pop(ctx);
+      },
+      child: Row(
+        children: [
+          Icon(
+            current == code
+                ? Icons.radio_button_checked
+                : Icons.radio_button_off,
+            color: AppColors.primary,
+            size: 20,
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Text(label),
         ],
       ),
     );
@@ -155,7 +233,26 @@ class ProfileScreen extends ConsumerWidget {
     }
   }
 
-  Widget _buildMenuItem(
+  // -------- Widgets --------
+
+  Widget _infoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: const TextStyle(color: AppColors.textSecondary)),
+          const SizedBox(width: AppSpacing.md),
+          Flexible(
+              child: Text(value,
+                  textAlign: TextAlign.right,
+                  overflow: TextOverflow.ellipsis)),
+        ],
+      ),
+    );
+  }
+
+  Widget _menuItem(
     BuildContext context, {
     required IconData icon,
     required String label,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:fitness_ai/core/locale_provider.dart';
 import 'package:fitness_ai/core/router/app_router.dart';
 import 'package:fitness_ai/core/storage/hive_storage.dart';
 import 'package:fitness_ai/core/theme/app_theme.dart';
@@ -23,6 +24,7 @@ class FitnessAIApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(appRouterProvider);
+    final locale = ref.watch(localeProvider);
 
     return MaterialApp.router(
       title: 'FitnessAI',
@@ -36,7 +38,7 @@ class FitnessAIApp extends ConsumerWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: S.supportedLocales,
-      locale: const Locale('it'),
+      locale: locale,
     );
   }
 }

--- a/app/web/webauthn.js
+++ b/app/web/webauthn.js
@@ -22,6 +22,19 @@ window.fitnessWebAuthnSupported = function () {
   return !!(window.PublicKeyCredential && navigator.credentials && navigator.credentials.create);
 };
 
+// Trigger a browser download of a text file (used for GDPR data export).
+window.fitnessDownload = function (filename, text) {
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
+
 // options: { challenge, rp_id, rp_name, user_id, user_name, timeout }
 window.fitnessWebAuthnRegister = async function (optionsJson) {
   const o = JSON.parse(optionsJson);


### PR DESCRIPTION
Dai feedback d'uso: la schermata Profilo era placeholder (header 'Utente' fisso, pulsanti con onTap vuoto).

- **Header**: nome/email reali + crediti AI dall'utente autenticato.
- **Impostazioni**: dialog info account.
- **Esporta Dati**: download JSON GDPR (/auth/me/export).
- **Lingua**: selettore IT/EN persistito (localeProvider) wired in MaterialApp.

Solo app Flutter, backend invariato. Verificato live: header mostra nome reale + 10 crediti.

🤖 Generated with [Claude Code](https://claude.com/claude-code)