### PR TITLE
Crea-scheda manuale + Disclaimer

### DIFF
--- a/app/lib/core/disclaimer.dart
+++ b/app/lib/core/disclaimer.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import 'package:fitness_ai/core/storage/hive_storage.dart';
+import 'package:fitness_ai/core/theme/app_colors.dart';
+
+const String kDisclaimerText =
+    'FitnessAI fornisce schede di allenamento e statistiche a scopo '
+    'informativo e di auto-monitoraggio. NON è un servizio medico e non '
+    'sostituisce il parere di un medico o di un professionista qualificato.\n\n'
+    'Consulta un medico prima di iniziare un programma di allenamento, '
+    'soprattutto in caso di patologie, infortuni o dubbi sul tuo stato di '
+    'salute. Interrompi l\'attività e rivolgiti a un medico se avverti dolore '
+    'o malessere.\n\n'
+    'Svolgendo gli esercizi ti assumi la responsabilità della corretta '
+    'esecuzione. Le eventuali foto caricate servono solo a generare i tuoi '
+    'contenuti e puoi chiederne la cancellazione in qualsiasi momento '
+    '(Profilo → Esci / contatta l\'amministratore).';
+
+const _acceptedKey = 'disclaimer_accepted';
+
+bool disclaimerAccepted() => HiveStorage.user.get(_acceptedKey) == true;
+
+/// Show the disclaimer. When [gate] is true it requires explicit acceptance
+/// (used once on first access); otherwise it is just an informational view.
+Future<void> showDisclaimerDialog(BuildContext context, {bool gate = false}) {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: !gate,
+    builder: (ctx) => AlertDialog(
+      backgroundColor: AppColors.bgSecondary,
+      title: const Text('Disclaimer & Privacy'),
+      content: const SingleChildScrollView(child: Text(kDisclaimerText)),
+      actions: [
+        if (gate)
+          TextButton(
+            onPressed: () {
+              HiveStorage.user.put(_acceptedKey, true);
+              Navigator.pop(ctx);
+            },
+            child: const Text('Ho capito e accetto'),
+          )
+        else
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Chiudi'),
+          ),
+      ],
+    ),
+  );
+}

--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:fitness_ai/core/disclaimer.dart';
 import 'package:fitness_ai/features/auth/domain/auth_state.dart';
 import 'package:fitness_ai/features/auth/presentation/auth_notifier.dart';
 import 'package:fitness_ai/features/auth/presentation/login_screen.dart';
@@ -24,6 +25,16 @@ class MainShell extends StatefulWidget {
 }
 
 class _MainShellState extends State<MainShell> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && !disclaimerAccepted()) {
+        showDisclaimerDialog(context, gate: true);
+      }
+    });
+  }
+
   int _indexForLocation(String location) {
     if (location.startsWith('/history')) return 1;
     if (location.startsWith('/stats')) return 2;

--- a/app/lib/features/profile/presentation/profile_screen.dart
+++ b/app/lib/features/profile/presentation/profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:fitness_ai/core/auth/webauthn.dart' as webauthn;
+import 'package:fitness_ai/core/disclaimer.dart';
 import 'package:fitness_ai/core/locale_provider.dart';
 import 'package:fitness_ai/core/theme/app_colors.dart';
 import 'package:fitness_ai/core/theme/app_spacing.dart';
@@ -105,6 +106,10 @@ class ProfileScreen extends ConsumerWidget {
                   ? 'Face ID attivo'
                   : 'Abilita Face ID',
               onTap: () => _enableFaceId(context, ref)),
+        _menuItem(context,
+            icon: Icons.shield_outlined,
+            label: 'Disclaimer e Privacy',
+            onTap: () => showDisclaimerDialog(context)),
         const Spacer(),
         GlowButton(
           label: 'Esci',

--- a/app/lib/features/workout/data/workout_repository.dart
+++ b/app/lib/features/workout/data/workout_repository.dart
@@ -128,6 +128,42 @@ class WorkoutRepository {
     }
   }
 
+  /// Create a new workout plan on the server and cache it locally.
+  Future<WorkoutPlan> createPlan({
+    required String name,
+    String? description,
+    required List<WorkoutDay> days,
+  }) async {
+    try {
+      final response = await apiClient.post(
+        ApiConstants.workoutPlans,
+        data: {
+          'name': name,
+          if (description != null && description.isNotEmpty)
+            'description': description,
+          'source': 'manual',
+          'days': days
+              .map((d) => {
+                    'name': d.name,
+                    'exercises': d.exercises
+                        .map((e) => {
+                              'exercise_name': e.exerciseName,
+                              'sets': e.sets,
+                              'reps': e.reps,
+                            })
+                        .toList(),
+                  })
+              .toList(),
+        },
+      );
+      final plan = WorkoutPlan.fromJson(response.data as Map<String, dynamic>);
+      await HiveStorage.plans.put(plan.id, plan.toJson());
+      return plan;
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
   /// Get cached plans from Hive (for offline use).
   List<WorkoutPlan> getCachedPlans() {
     return HiveStorage.plans.values

--- a/app/lib/features/workout/presentation/create_plan_screen.dart
+++ b/app/lib/features/workout/presentation/create_plan_screen.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
+import 'package:fitness_ai/core/widgets/widgets.dart';
+import 'package:fitness_ai/features/workout/data/workout_repository.dart';
+import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
+import 'package:fitness_ai/features/workout/presentation/active_plan_provider.dart';
+
+class _ExDraft {
+  final name = TextEditingController();
+  final sets = TextEditingController(text: '3');
+  final reps = TextEditingController(text: '10');
+  void dispose() {
+    name.dispose();
+    sets.dispose();
+    reps.dispose();
+  }
+}
+
+class _DayDraft {
+  _DayDraft(String initialName) : name = TextEditingController(text: initialName);
+  final TextEditingController name;
+  final List<_ExDraft> exercises = [_ExDraft()];
+  void dispose() {
+    name.dispose();
+    for (final e in exercises) {
+      e.dispose();
+    }
+  }
+}
+
+/// Manual workout-plan builder: name + days + exercises (sets/reps), saved
+/// to the server. Used when the user has no plan yet (no AI coach needed).
+class CreatePlanScreen extends ConsumerStatefulWidget {
+  const CreatePlanScreen({super.key});
+
+  @override
+  ConsumerState<CreatePlanScreen> createState() => _CreatePlanScreenState();
+}
+
+class _CreatePlanScreenState extends ConsumerState<CreatePlanScreen> {
+  final _planName = TextEditingController(text: 'La mia scheda');
+  final List<_DayDraft> _days = [_DayDraft('Giorno 1')];
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _planName.dispose();
+    for (final d in _days) {
+      d.dispose();
+    }
+    super.dispose();
+  }
+
+  void _addDay() =>
+      setState(() => _days.add(_DayDraft('Giorno ${_days.length + 1}')));
+  void _removeDay(int i) => setState(() {
+        _days[i].dispose();
+        _days.removeAt(i);
+      });
+  void _addEx(int dayIdx) =>
+      setState(() => _days[dayIdx].exercises.add(_ExDraft()));
+  void _removeEx(int dayIdx, int exIdx) => setState(() {
+        _days[dayIdx].exercises[exIdx].dispose();
+        _days[dayIdx].exercises.removeAt(exIdx);
+      });
+
+  Future<void> _save() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final name = _planName.text.trim();
+    if (name.isEmpty) {
+      messenger.showSnackBar(
+          const SnackBar(content: Text('Dai un nome alla scheda')));
+      return;
+    }
+    final days = <WorkoutDay>[];
+    for (final d in _days) {
+      final exs = <PlannedExercise>[];
+      for (final e in d.exercises) {
+        final exName = e.name.text.trim();
+        if (exName.isEmpty) continue;
+        exs.add(PlannedExercise(
+          exerciseName: exName,
+          sets: int.tryParse(e.sets.text.trim()) ?? 3,
+          reps: e.reps.text.trim().isEmpty ? '10' : e.reps.text.trim(),
+        ));
+      }
+      if (exs.isNotEmpty) {
+        final dayName = d.name.text.trim();
+        days.add(WorkoutDay(
+            name: dayName.isEmpty ? 'Giorno' : dayName, exercises: exs));
+      }
+    }
+    if (days.isEmpty) {
+      messenger.showSnackBar(
+          const SnackBar(content: Text('Aggiungi almeno un esercizio')));
+      return;
+    }
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(workoutRepositoryProvider)
+          .createPlan(name: name, days: days);
+      ref.invalidate(activePlanProvider);
+      if (mounted) {
+        messenger.showSnackBar(const SnackBar(
+          content: Text('Scheda creata!'),
+          backgroundColor: AppColors.success,
+        ));
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _saving = false);
+        messenger.showSnackBar(SnackBar(
+          content: Text('Errore: $e'),
+          backgroundColor: AppColors.error,
+        ));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.bgPrimary,
+      appBar: AppBar(title: const Text('Crea scheda')),
+      body: ListView(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        children: [
+          TextField(
+            controller: _planName,
+            decoration: const InputDecoration(labelText: 'Nome scheda'),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          ..._days.asMap().entries.map((e) => _dayCard(e.key, e.value)),
+          OutlinedButton.icon(
+            onPressed: _addDay,
+            icon: const Icon(Icons.add),
+            label: const Text('Aggiungi giorno'),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          GlowButton(
+            label: _saving ? 'Salvataggio...' : 'Salva scheda',
+            onPressed: _save,
+            enabled: !_saving,
+            icon: Icons.check,
+          ),
+          const SizedBox(height: AppSpacing.xl),
+        ],
+      ),
+    );
+  }
+
+  Widget _dayCard(int dayIdx, _DayDraft day) {
+    return GlassmorphismCard(
+      margin: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: day.name,
+                  decoration: const InputDecoration(labelText: 'Nome giorno'),
+                ),
+              ),
+              if (_days.length > 1)
+                IconButton(
+                  onPressed: () => _removeDay(dayIdx),
+                  icon: const Icon(Icons.delete_outline,
+                      color: AppColors.error),
+                ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          ...day.exercises.asMap().entries.map((e) => _exRow(dayIdx, e.key, e.value)),
+          TextButton.icon(
+            onPressed: () => _addEx(dayIdx),
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('Aggiungi esercizio'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _exRow(int dayIdx, int exIdx, _ExDraft ex) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 5,
+            child: TextField(
+              controller: ex.name,
+              decoration: const InputDecoration(hintText: 'Esercizio'),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            flex: 2,
+            child: TextField(
+              controller: ex.sets,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'Serie'),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            flex: 2,
+            child: TextField(
+              controller: ex.reps,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'Reps'),
+            ),
+          ),
+          SizedBox(
+            width: 36,
+            child: IconButton(
+              padding: EdgeInsets.zero,
+              onPressed: () => _removeEx(dayIdx, exIdx),
+              icon: const Icon(Icons.close,
+                  size: 16, color: AppColors.textSecondary),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/workout/presentation/workout_home_screen.dart
+++ b/app/lib/features/workout/presentation/workout_home_screen.dart
@@ -8,6 +8,7 @@ import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
 import 'package:fitness_ai/features/workout/presentation/active_plan_provider.dart';
 import 'package:fitness_ai/features/workout/presentation/active_session_notifier.dart';
 import 'package:fitness_ai/features/workout/presentation/active_workout_screen.dart';
+import 'package:fitness_ai/features/workout/presentation/create_plan_screen.dart';
 
 /// Main workout screen: shows the active plan's days and starts a session.
 /// This is the default tab and the entry point of the app.
@@ -36,9 +37,9 @@ class WorkoutHomeScreen extends ConsumerWidget {
                 child: planAsync.when(
                   loading: () =>
                       const Center(child: CircularProgressIndicator()),
-                  error: (_, __) => _EmptyState(onReload: () => _reload(ref)),
+                  error: (_, __) => _EmptyState(onReload: () => _reload(ref), onCreate: () => _create(context, ref)),
                   data: (plan) => plan == null
-                      ? _EmptyState(onReload: () => _reload(ref))
+                      ? _EmptyState(onReload: () => _reload(ref), onCreate: () => _create(context, ref))
                       : _PlanView(plan: plan),
                 ),
               ),
@@ -50,6 +51,13 @@ class WorkoutHomeScreen extends ConsumerWidget {
   }
 
   void _reload(WidgetRef ref) => ref.invalidate(activePlanProvider);
+
+  Future<void> _create(BuildContext context, WidgetRef ref) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const CreatePlanScreen()),
+    );
+    ref.invalidate(activePlanProvider);
+  }
 }
 
 /// Shows the active plan and its days; tapping a day starts the workout.
@@ -126,9 +134,10 @@ class _PlanView extends ConsumerWidget {
 
 /// Shown when there is no active plan (offline with empty cache, or none yet).
 class _EmptyState extends StatelessWidget {
-  const _EmptyState({required this.onReload});
+  const _EmptyState({required this.onReload, required this.onCreate});
 
   final VoidCallback onReload;
+  final VoidCallback onCreate;
 
   @override
   Widget build(BuildContext context) {
@@ -151,9 +160,15 @@ class _EmptyState extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.lg),
             GlowButton(
-              label: 'Ricarica',
+              label: 'Crea scheda',
+              onPressed: onCreate,
+              icon: Icons.add,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            TextButton.icon(
               onPressed: onReload,
-              icon: Icons.refresh,
+              icon: const Icon(Icons.refresh, size: 18),
+              label: const Text('Ricarica'),
             ),
           ],
         ),


### PR DESCRIPTION
Per la beta famiglia/amici: nuovo utente puo creare la propria scheda in-app (CreatePlanScreen, salvata via /workouts/plans) dalla home vuota; + disclaimer medico/privacy come gate al primo accesso e voce in Profilo. Solo app Flutter, backend invariato. Build OK, registrazione+disclaimer verificati live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)