### PR TITLE
feat: attiva AI Coach + Vision (Opus 4.8, frontend sincrono, navigazione)

### DIFF
--- a/app/lib/features/ai/data/ai_repository.dart
+++ b/app/lib/features/ai/data/ai_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
@@ -6,87 +7,70 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fitness_ai/core/constants/api_constants.dart';
 import 'package:fitness_ai/core/network/api_client.dart';
 import 'package:fitness_ai/core/network/api_exception.dart';
-import 'package:fitness_ai/features/ai/domain/ai_job.dart';
 import 'package:fitness_ai/features/ai/domain/coach_result.dart';
+import 'package:fitness_ai/features/ai/domain/vision_result.dart';
 
 /// Repository for AI operations (vision scan, coach generation).
-/// All AI operations are async: submit job, poll for result.
+/// The backend processes these synchronously and returns the result
+/// directly in the HTTP response (no job polling).
 class AIRepository {
   AIRepository({required this.apiClient});
 
   final ApiClient apiClient;
 
-  /// Submit a vision scan image for equipment recognition.
-  Future<AIJob> submitVisionScan({
+  /// Scan an equipment image and return the recognized equipment + exercises.
+  Future<VisionResult> scanEquipment({
     required Uint8List imageBytes,
     required String filename,
   }) async {
     try {
-      final formData = FormData.fromMap({
-        'image': MultipartFile.fromBytes(
+      final form = FormData();
+      form.files.add(MapEntry(
+        'image',
+        MultipartFile.fromBytes(
           imageBytes,
-          filename: filename,
+          filename: filename.isNotEmpty ? filename : 'scan.jpg',
           contentType: DioMediaType('image', 'jpeg'),
         ),
-      });
+      ));
       final response = await apiClient.post(
         ApiConstants.aiVisionScan,
-        data: formData,
+        data: form,
         options: Options(contentType: 'multipart/form-data'),
       );
-      final data = response.data as Map<String, dynamic>;
-      return AIJob(
-        jobId: data['job_id'] as String,
-        jobType: 'vision_scan',
-        status: (data['status'] ?? 'pending') as String,
-      );
+      return VisionResult.fromJson(response.data as Map<String, dynamic>);
     } on DioException catch (e) {
       throw ApiException.fromDioException(e);
     }
   }
 
-  /// Submit a coach generation request.
-  Future<AIJob> submitCoachGeneration() async {
+  /// Generate a personalized workout plan from optional body photos + profile.
+  Future<CoachResult> generateCoachPlan({
+    required List<({Uint8List bytes, String filename})> photos,
+    required Map<String, dynamic> userData,
+  }) async {
     try {
-      final response = await apiClient.post(ApiConstants.aiCoachGenerate);
-      final data = response.data as Map<String, dynamic>;
-      return AIJob(
-        jobId: data['job_id'] as String,
-        jobType: 'coach_generate',
-        status: (data['status'] ?? 'pending') as String,
+      final form = FormData();
+      form.fields.add(MapEntry('data', jsonEncode(userData)));
+      for (final p in photos) {
+        form.files.add(MapEntry(
+          'photos',
+          MultipartFile.fromBytes(
+            p.bytes,
+            filename: p.filename,
+            contentType: DioMediaType('image', 'jpeg'),
+          ),
+        ));
+      }
+      final response = await apiClient.post(
+        ApiConstants.aiCoachGenerate,
+        data: form,
+        options: Options(contentType: 'multipart/form-data'),
       );
+      return CoachResult.fromJson(response.data as Map<String, dynamic>);
     } on DioException catch (e) {
       throw ApiException.fromDioException(e);
     }
-  }
-
-  /// Poll job status. Returns the job with current status and result.
-  Future<AIJob> getJobStatus(String jobId) async {
-    try {
-      final response = await apiClient.get('/ai/jobs/$jobId');
-      return AIJob.fromJson(response.data as Map<String, dynamic>);
-    } on DioException catch (e) {
-      throw ApiException.fromDioException(e);
-    }
-  }
-
-  /// Poll until job completes or fails (max attempts).
-  /// Returns the completed job or throws on timeout/failure.
-  Future<AIJob> pollUntilComplete(String jobId, {int maxAttempts = 60}) async {
-    for (int i = 0; i < maxAttempts; i++) {
-      await Future.delayed(const Duration(seconds: 2));
-      final job = await getJobStatus(jobId);
-      if (job.isCompleted || job.isFailed) return job;
-    }
-    throw const ApiException(message: 'Job timed out after 2 minutes.');
-  }
-
-  /// Parse a coach result from a completed job.
-  CoachResult parseCoachResult(AIJob job) {
-    if (job.result == null) {
-      throw const ApiException(message: 'Job has no result.');
-    }
-    return CoachResult.fromJson(job.result!);
   }
 }
 

--- a/app/lib/features/ai/domain/coach_result.dart
+++ b/app/lib/features/ai/domain/coach_result.dart
@@ -21,7 +21,7 @@ class CoachResult {
       days: ((json['days'] ?? []) as List)
           .map((d) => WorkoutDay.fromJson(d as Map<String, dynamic>))
           .toList(),
-      notes: json['notes'] as String?,
+      notes: (json['notes'] ?? json['progression_notes']) as String?,
     );
   }
 

--- a/app/lib/features/ai/presentation/coach_onboarding_screen.dart
+++ b/app/lib/features/ai/presentation/coach_onboarding_screen.dart
@@ -129,45 +129,41 @@ class _CoachOnboardingScreenState
     });
 
     try {
-      // Update user profile with personal data
-      final age = int.tryParse(_ageController.text);
-      if (age != null) {
-        // Profile update would go here if we had the auth repo available
-      }
-
       setState(() => _generationStatus = 'Generazione scheda personalizzata...');
 
+      final photos = <({Uint8List bytes, String filename})>[];
+      if (_frontPhoto != null) {
+        photos.add((bytes: _frontPhoto!, filename: 'front.jpg'));
+      }
+      if (_backPhoto != null) {
+        photos.add((bytes: _backPhoto!, filename: 'back.jpg'));
+      }
+      if (_sidePhoto != null) {
+        photos.add((bytes: _sidePhoto!, filename: 'side.jpg'));
+      }
+
+      final userData = <String, dynamic>{
+        if (int.tryParse(_ageController.text) != null)
+          'age': int.parse(_ageController.text),
+        'goals': _goal,
+        'available_days': _frequency,
+        if (_limitationsController.text.trim().isNotEmpty)
+          'limitations': _limitationsController.text.trim(),
+      };
+
       final aiRepo = ref.read(aiRepositoryProvider);
-      final job = await aiRepo.submitCoachGeneration();
+      final result = await aiRepo.generateCoachPlan(
+        photos: photos,
+        userData: userData,
+      );
 
-      setState(() => _generationStatus = 'Analisi in corso...');
-
-      final completedJob = await aiRepo.pollUntilComplete(job.jobId);
-
-      if (completedJob.isCompleted && completedJob.result != null) {
-        final result = aiRepo.parseCoachResult(completedJob);
-        setState(() => _isGenerating = false);
-
-        if (mounted) {
-          Navigator.of(context).pushReplacement(
-            MaterialPageRoute(
-              builder: (_) => CoachResultScreen(result: result),
-            ),
-          );
-        }
-      } else {
-        setState(() {
-          _isGenerating = false;
-          _generationStatus = completedJob.error ?? 'Generazione fallita';
-        });
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(completedJob.error ?? 'Errore durante la generazione'),
-              backgroundColor: AppColors.error,
-            ),
-          );
-        }
+      setState(() => _isGenerating = false);
+      if (mounted) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (_) => CoachResultScreen(result: result),
+          ),
+        );
       }
     } catch (e) {
       setState(() {

--- a/app/lib/features/ai/presentation/coach_result_screen.dart
+++ b/app/lib/features/ai/presentation/coach_result_screen.dart
@@ -5,6 +5,8 @@ import 'package:fitness_ai/core/theme/app_colors.dart';
 import 'package:fitness_ai/core/theme/app_spacing.dart';
 import 'package:fitness_ai/core/widgets/widgets.dart';
 import 'package:fitness_ai/features/ai/domain/coach_result.dart';
+import 'package:fitness_ai/features/workout/data/workout_repository.dart';
+import 'package:fitness_ai/features/workout/presentation/active_plan_provider.dart';
 
 /// Screen showing the AI-generated workout plan.
 /// Allows the user to review, save, or modify the plan.
@@ -87,9 +89,26 @@ class CoachResultScreen extends ConsumerWidget {
                 children: [
                   GlowButton(
                     label: 'Salva Scheda',
-                    onPressed: () {
-                      // TODO: Save plan via API and navigate back
-                      Navigator.of(context).pop();
+                    onPressed: () async {
+                      final messenger = ScaffoldMessenger.of(context);
+                      final navigator = Navigator.of(context);
+                      try {
+                        await ref.read(workoutRepositoryProvider).createPlan(
+                              name: result.planName,
+                              days: result.days,
+                            );
+                        ref.invalidate(activePlanProvider);
+                        messenger.showSnackBar(const SnackBar(
+                          content: Text('Scheda salvata!'),
+                          backgroundColor: AppColors.success,
+                        ));
+                        navigator.popUntil((r) => r.isFirst);
+                      } catch (e) {
+                        messenger.showSnackBar(SnackBar(
+                          content: Text('Errore nel salvataggio: $e'),
+                          backgroundColor: AppColors.error,
+                        ));
+                      }
                     },
                     icon: Icons.save,
                     color: AppColors.success,

--- a/app/lib/features/ai/presentation/vision_scan_screen.dart
+++ b/app/lib/features/ai/presentation/vision_scan_screen.dart
@@ -81,27 +81,16 @@ class _VisionScanScreenState extends ConsumerState<VisionScanScreen> {
     });
 
     try {
+      setState(() => _statusMessage = 'Analisi in corso...');
       final aiRepo = ref.read(aiRepositoryProvider);
-      final job = await aiRepo.submitVisionScan(
+      final result = await aiRepo.scanEquipment(
         imageBytes: bytes,
         filename: filename,
       );
-
-      setState(() => _statusMessage = 'Analisi in corso...');
-
-      final completedJob = await aiRepo.pollUntilComplete(job.jobId);
-
-      if (completedJob.isCompleted && completedJob.result != null) {
-        setState(() {
-          _result = VisionResult.fromJson(completedJob.result!);
-          _isScanning = false;
-        });
-      } else {
-        setState(() {
-          _error = completedJob.error ?? 'Macchinario non riconosciuto';
-          _isScanning = false;
-        });
-      }
+      setState(() {
+        _result = result;
+        _isScanning = false;
+      });
     } catch (e) {
       setState(() {
         _error = e.toString();

--- a/app/lib/features/workout/presentation/workout_home_screen.dart
+++ b/app/lib/features/workout/presentation/workout_home_screen.dart
@@ -9,6 +9,8 @@ import 'package:fitness_ai/features/workout/presentation/active_plan_provider.da
 import 'package:fitness_ai/features/workout/presentation/active_session_notifier.dart';
 import 'package:fitness_ai/features/workout/presentation/active_workout_screen.dart';
 import 'package:fitness_ai/features/workout/presentation/create_plan_screen.dart';
+import 'package:fitness_ai/features/ai/presentation/coach_onboarding_screen.dart';
+import 'package:fitness_ai/features/ai/presentation/vision_scan_screen.dart';
 
 /// Main workout screen: shows the active plan's days and starts a session.
 /// This is the default tab and the entry point of the app.
@@ -32,6 +34,8 @@ class WorkoutHomeScreen extends ConsumerWidget {
               ),
               const SizedBox(height: AppSpacing.xs),
               Text('Oggi', style: Theme.of(context).textTheme.headlineMedium),
+              const SizedBox(height: AppSpacing.md),
+              const _AiActions(),
               const SizedBox(height: AppSpacing.lg),
               Expanded(
                 child: planAsync.when(
@@ -172,6 +176,89 @@ class _EmptyState extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Two entry points to the AI features (Coach generation + equipment scan).
+class _AiActions extends StatelessWidget {
+  const _AiActions();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _AiCard(
+            icon: Icons.auto_awesome,
+            label: 'Coach AI',
+            subtitle: 'Genera scheda',
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const CoachOnboardingScreen()),
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: _AiCard(
+            icon: Icons.camera_alt,
+            label: 'Scansiona',
+            subtitle: 'Riconosci attrezzo',
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const VisionScanScreen()),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AiCard extends StatelessWidget {
+  const _AiCard({
+    required this.icon,
+    required this.label,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassmorphismCard(
+      onTap: onTap,
+      padding: const EdgeInsets.all(AppSpacing.md),
+      borderColor: AppColors.primary.withValues(alpha: 0.25),
+      child: Row(
+        children: [
+          Icon(icon, color: AppColors.primary, size: 26),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleSmall
+                      ?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                Text(
+                  subtitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/services/ai/app/claude_client.py
+++ b/services/ai/app/claude_client.py
@@ -25,8 +25,8 @@ from app.prompts.vision_scan import (
 
 logger = logging.getLogger(__name__)
 
-# Claude model for vision tasks
-CLAUDE_MODEL = "claude-sonnet-4-20250514"
+# Claude model for vision + coach tasks (configurable via CLAUDE_MODEL env).
+CLAUDE_MODEL = settings.claude_model
 MAX_TOKENS = 4096
 
 # Supported image MIME types for Claude Vision API

--- a/services/ai/app/config.py
+++ b/services/ai/app/config.py
@@ -17,6 +17,10 @@ class Settings(BaseSettings):
 
     # Anthropic
     anthropic_api_key: str = ""
+    # Claude model for vision + coach (override via CLAUDE_MODEL in .env).
+    # e.g. claude-opus-4-8 (max quality), claude-sonnet-4-6 (balanced),
+    # claude-haiku-4-5-20251001 (cheapest).
+    claude_model: str = "claude-sonnet-4-6"
 
     # Redis (cache + job queue)
     redis_url: str = "redis://redis:6379/0"

--- a/services/ai/app/router.py
+++ b/services/ai/app/router.py
@@ -172,7 +172,7 @@ async def vision_history(
 
 @router.post("/coach/generate", response_model=CoachGenerateSyncResponse)
 async def coach_generate(
-    photos: list[UploadFile] = File(...),
+    photos: list[UploadFile] | None = File(None),
     data: str = Form("{}"),
     user_id: uuid.UUID = Depends(get_current_user_id),
     token: str = Depends(_get_token),
@@ -196,12 +196,8 @@ async def coach_generate(
     Returns:
         Generated workout plan with exercises.
     """
-    # Validate photo count
-    if len(photos) == 0:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="At least one photo is required",
-        )
+    # Photos are optional: a plan can be generated from the questionnaire alone.
+    photos = photos or []
     if len(photos) > MAX_COACH_PHOTOS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/services/ai/migrations/0001_create_ai_schema.sql
+++ b/services/ai/migrations/0001_create_ai_schema.sql
@@ -1,0 +1,38 @@
+-- Migration 0001: create the AI service schema and tables.
+--
+-- The ai service uses SQLAlchemy models but does NOT auto-create tables on
+-- startup (no create_all/lifespan), matching the other services. This file
+-- records the DDL to provision the ai schema on a database.
+--
+-- Idempotent: safe to run multiple times.
+-- Apply on the server with:
+--   docker compose exec -T db psql -U fitnessai -d fitness_ai -f - < 0001_create_ai_schema.sql
+
+CREATE SCHEMA IF NOT EXISTS ai;
+
+CREATE TABLE IF NOT EXISTS ai.ai_vision_scans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    image_hash VARCHAR(64),
+    equipment_name VARCHAR(255),
+    equipment_brand VARCHAR(100),
+    exercises JSONB,
+    raw_response JSONB,
+    credits_used INTEGER DEFAULT 1,
+    error TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS ix_ai_vision_scans_user_id ON ai.ai_vision_scans (user_id);
+
+CREATE TABLE IF NOT EXISTS ai.ai_coach_generations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    input_data JSONB,
+    photo_count INTEGER,
+    generated_plan JSONB,
+    raw_response JSONB,
+    credits_used INTEGER DEFAULT 5,
+    error TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS ix_ai_coach_generations_user_id ON ai.ai_coach_generations (user_id);

--- a/services/ai/tests/test_coach.py
+++ b/services/ai/tests/test_coach.py
@@ -111,6 +111,23 @@ async def test_coach_generate_success(fake_redis, auth_headers, mock_coach_resul
 
 
 @pytest.mark.asyncio
+async def test_coach_generate_without_photos(fake_redis, auth_headers, mock_coach_result):
+    """Coach generation should work from the questionnaire alone (no photos)."""
+    patches = _build_patches(fake_redis, coach_result=mock_coach_result)
+
+    with patches[0], patches[1], patches[2], patches[3]:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/ai/coach/generate",
+                data={"data": json.dumps({"age": 30, "goals": "muscle", "available_days": 4})},
+                headers=auth_headers,
+            )
+            assert response.status_code == 200
+            assert response.json()["plan_name"] == "Beginner Full Body"
+
+
+@pytest.mark.asyncio
 async def test_coach_generate_multiple_photos(fake_redis, auth_headers, mock_coach_result):
     """Multiple photos should be accepted."""
     patches = _build_patches(fake_redis, coach_result=mock_coach_result)


### PR DESCRIPTION
Attiva i servizi AI per il test interno (qualità massima = Opus 4.8).

## Backend (ai)
- **Modello configurabile** via `CLAUDE_MODEL` (default `claude-sonnet-4-6`); in produzione `claude-opus-4-8`. Prima era hardcoded a un modello datato.
- `/ai/coach/generate`: **foto opzionali** (piano generabile dal solo questionario) + test.
- Migrazione SQL idempotente per lo schema `ai` (`ai_vision_scans`, `ai_coach_generations`) — il servizio non crea le tabelle da solo.

## Frontend (app)
Le schermate AI erano **orfane** (non raggiungibili) e il contratto era **async job/poll** mentre il backend risponde **sincrono**. Riconciliato:
- `ai_repository` ora sincrono: `scanEquipment()` e `generateCoachPlan(photos, userData)`.
- Vision scan: usa la chiamata diretta.
- Coach onboarding: ora **invia davvero** foto + dati (age/goals/available_days/limitations) — prima non inviava nulla.
- Coach result: **"Salva Scheda"** salva il piano generato e lo rende attivo.
- Workout home: aggiunti due ingressi **Coach AI** e **Scansiona**.

## Note
- Backend deployato su EC2 con `redis` + `ai` (stack core finora senza AI). Chiave Anthropic solo nel `.env` del server.
- Modello: max qualità ora per test su singolo utente; si abbasserà (Haiku/Sonnet) prima della diffusione cambiando solo `CLAUDE_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)