### PR TITLE
fix(ai): max_tokens configurabile (8192) per piani Coach completi

### DIFF
--- a/services/ai/app/claude_client.py
+++ b/services/ai/app/claude_client.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # Claude model for vision + coach tasks (configurable via CLAUDE_MODEL env).
 CLAUDE_MODEL = settings.claude_model
-MAX_TOKENS = 4096
+MAX_TOKENS = settings.claude_max_tokens
 
 # Supported image MIME types for Claude Vision API
 VALID_IMAGE_TYPES = ("image/jpeg", "image/png", "image/gif", "image/webp")

--- a/services/ai/app/config.py
+++ b/services/ai/app/config.py
@@ -21,6 +21,9 @@ class Settings(BaseSettings):
     # e.g. claude-opus-4-8 (max quality), claude-sonnet-4-6 (balanced),
     # claude-haiku-4-5-20251001 (cheapest).
     claude_model: str = "claude-sonnet-4-6"
+    # Max output tokens. A full multi-day coach plan in JSON can be large, so
+    # keep this generous to avoid truncated (unparseable) responses.
+    claude_max_tokens: int = 8192
 
     # Redis (cache + job queue)
     redis_url: str = "redis://redis:6379/0"


### PR DESCRIPTION
I piani Coach multi-giorno con Opus superavano `MAX_TOKENS=4096` e venivano **troncati** → JSON non parsabile (HTTP 500). Verificato dal vivo: con 8192 token Opus genera un piano 4-giorni completo dalle foto reali.

- `claude_max_tokens` in config (default 8192, override via `CLAUDE_MAX_TOKENS`).
- `MAX_TOKENS = settings.claude_max_tokens` in claude_client (vision + coach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)