### PR TITLE
fix: crash Storico/Grafici/avvio allenamento dopo reload (cast Map Hive)

### DIFF
--- a/app/lib/features/history/data/history_repository.dart
+++ b/app/lib/features/history/data/history_repository.dart
@@ -15,12 +15,20 @@ class HistoryRepository {
   final ApiClient apiClient;
 
   /// Get all local sessions sorted by date (newest first).
+  /// Parsing is per-record defensive: a single malformed cached entry can
+  /// never blank the whole screen.
   List<WorkoutSession> getLocalSessions() {
-    return HiveStorage.sessions.values
-        .map((m) => WorkoutSession.fromJson(Map<String, dynamic>.from(m)))
-        .where((s) => s.isCompleted)
-        .toList()
-      ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    final out = <WorkoutSession>[];
+    for (final m in HiveStorage.sessions.values) {
+      try {
+        final s = WorkoutSession.fromJson(Map<String, dynamic>.from(m as Map));
+        if (s.isCompleted) out.add(s);
+      } catch (_) {
+        // skip corrupt/incompatible cached record
+      }
+    }
+    out.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    return out;
   }
 
   /// Fetch sessions from API and cache locally.

--- a/app/lib/features/workout/data/workout_repository.dart
+++ b/app/lib/features/workout/data/workout_repository.dart
@@ -36,11 +36,19 @@ class WorkoutRepository {
   }
 
   /// Get all local sessions, most recent first.
+  /// Per-record defensive parsing so a malformed cached entry can't break
+  /// session start / history.
   List<WorkoutSession> getAllLocalSessions() {
-    return HiveStorage.sessions.values
-        .map((m) => WorkoutSession.fromJson(Map<String, dynamic>.from(m)))
-        .toList()
-      ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    final out = <WorkoutSession>[];
+    for (final m in HiveStorage.sessions.values) {
+      try {
+        out.add(WorkoutSession.fromJson(Map<String, dynamic>.from(m as Map)));
+      } catch (_) {
+        // skip corrupt/incompatible cached record
+      }
+    }
+    out.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    return out;
   }
 
   /// Get unsynced sessions that need to be sent to the API.
@@ -171,9 +179,15 @@ class WorkoutRepository {
 
   /// Get cached plans from Hive (for offline use).
   List<WorkoutPlan> getCachedPlans() {
-    return HiveStorage.plans.values
-        .map((m) => WorkoutPlan.fromJson(Map<String, dynamic>.from(m)))
-        .toList();
+    final out = <WorkoutPlan>[];
+    for (final m in HiveStorage.plans.values) {
+      try {
+        out.add(WorkoutPlan.fromJson(Map<String, dynamic>.from(m as Map)));
+      } catch (_) {
+        // skip corrupt/incompatible cached record
+      }
+    }
+    return out;
   }
 
   // ============================================================

--- a/app/lib/features/workout/domain/exercise_log.dart
+++ b/app/lib/features/workout/domain/exercise_log.dart
@@ -64,7 +64,7 @@ class ExerciseLog {
       restSeconds:
           (json['rest_seconds'] ?? json['restSeconds'] ?? 90) as int,
       sets: ((json['sets'] ?? []) as List)
-          .map((s) => SetLog.fromJson(s as Map<String, dynamic>))
+          .map((s) => SetLog.fromJson(Map<String, dynamic>.from(s as Map)))
           .toList(),
       skipped: (json['skipped'] ?? false) as bool,
       notes: (json['notes'] ?? '') as String,

--- a/app/lib/features/workout/domain/workout_plan.dart
+++ b/app/lib/features/workout/domain/workout_plan.dart
@@ -35,12 +35,12 @@ class WorkoutPlan {
       name: json['name'] as String,
       description: json['description'] as String?,
       days: ((json['days'] ?? []) as List)
-          .map((d) => WorkoutDay.fromJson(d as Map<String, dynamic>))
+          .map((d) => WorkoutDay.fromJson(Map<String, dynamic>.from(d as Map)))
           .toList(),
       isActive: (json['is_active'] ?? true) as bool,
       source: (json['source'] ?? 'manual') as String,
       phases: (json['phases'] as List?)
-          ?.map((p) => p as Map<String, dynamic>)
+          ?.map((p) => Map<String, dynamic>.from(p as Map))
           .toList(),
       createdAt: json['created_at'] != null
           ? DateTime.parse(json['created_at'].toString())
@@ -90,7 +90,7 @@ class WorkoutDay {
     return WorkoutDay(
       name: json['name'] as String,
       exercises: ((json['exercises'] ?? []) as List)
-          .map((e) => PlannedExercise.fromJson(e as Map<String, dynamic>))
+          .map((e) => PlannedExercise.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
       warmup: ((json['warmup'] ?? []) as List).cast<String>(),
     );

--- a/app/lib/features/workout/domain/workout_session.dart
+++ b/app/lib/features/workout/domain/workout_session.dart
@@ -111,7 +111,7 @@ class WorkoutSession {
           : null,
       durationSeconds: json['duration_seconds'] as int?,
       exercises: ((json['exercises'] ?? []) as List)
-          .map((e) => ExerciseLog.fromJson(e as Map<String, dynamic>))
+          .map((e) => ExerciseLog.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
       notes: (json['notes'] ?? '') as String,
       synced: (json['synced'] ?? false) as bool,

--- a/app/test/features/workout/workout_session_hive_test.dart
+++ b/app/test/features/workout/workout_session_hive_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
+
+void main() {
+  group('Hive-style deserialization (Map<dynamic,dynamic>)', () {
+    // After a page reload, Hive returns nested maps as Map<dynamic,dynamic>
+    // (not Map<String,dynamic>). Parsing must not throw on these, otherwise
+    // the History/Stats screens and session start crash (blank screens).
+
+    test('WorkoutSession.fromJson handles nested Map<dynamic,dynamic>', () {
+      final Map<dynamic, dynamic> hive = <dynamic, dynamic>{
+        'id': 's1',
+        'started_at': '2026-06-01T10:00:00.000',
+        'completed_at': '2026-06-01T11:00:00.000',
+        'exercises': <dynamic>[
+          <dynamic, dynamic>{
+            'exercise_name': 'Panca',
+            'sets': <dynamic>[
+              <dynamic, dynamic>{
+                'set_number': 1,
+                'weight': 60,
+                'actual_reps': 10,
+                'completed': true,
+              },
+            ],
+          },
+        ],
+        'rating': 4,
+      };
+
+      final s = WorkoutSession.fromJson(Map<String, dynamic>.from(hive));
+      expect(s.exercises.length, 1);
+      expect(s.exercises.first.sets.first.weight, 60);
+      expect(s.exercises.first.sets.first.actualReps, 10);
+      expect(s.totalCompletedSets, 1);
+      expect(s.overallRating, 4); // legacy 'rating' maps to overall
+    });
+
+    test('WorkoutPlan.fromJson handles nested Map<dynamic,dynamic>', () {
+      final Map<dynamic, dynamic> hive = <dynamic, dynamic>{
+        'id': 'p1',
+        'name': 'Scheda',
+        'days': <dynamic>[
+          <dynamic, dynamic>{
+            'name': 'Push',
+            'warmup': <dynamic>['5 min cardio'],
+            'exercises': <dynamic>[
+              <dynamic, dynamic>{
+                'exercise_name': 'Panca',
+                'sets': 4,
+                'reps': '8',
+                'rest_seconds': 120,
+              },
+            ],
+          },
+        ],
+      };
+
+      final p = WorkoutPlan.fromJson(Map<String, dynamic>.from(hive));
+      expect(p.days.length, 1);
+      expect(p.days.first.exercises.first.exerciseName, 'Panca');
+      expect(p.days.first.exercises.first.sets, 4);
+      expect(p.days.first.warmup, ['5 min cardio']);
+    });
+  });
+}


### PR DESCRIPTION
## Bug
Dopo un **reload** dell'app: Storico e Grafici **bianchi**, le **schede non si aprivano**; Coach/Vision/Nutrizione/Profilo ok.

## Causa
Quelle schermate leggono le sessioni dalla **cache Hive**. Entro la stessa sessione le mappe sono in-memory (`Map<String,dynamic>`) → ok. Dopo un reload Hive le rilegge da disco come **`Map<dynamic,dynamic>`**, quindi `x as Map<String,dynamic>` nei `fromJson` **lanciava** → crash delle schermate che leggono sessioni (e di `startSession`). Le altre schermate non leggono sessioni → funzionavano. (Per questo i test "fresh" non lo intercettavano: nessun reload.)

## Fix
- `fromJson` (WorkoutSession/ExerciseLog/WorkoutPlan/WorkoutDay): mappe annidate con `Map<String,dynamic>.from(x as Map)`.
- `getLocalSessions`/`getAllLocalSessions`/`getCachedPlans`: parsing per-record difensivo.
- Test unit: deserializzazione stile-Hive (`Map<dynamic,dynamic>`). Verificato live con reload: Grafici/Storico/avvio allenamento ora OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)