### PR TITLE
feat: pre-fill pesi per esercizio + nomi consistenti + coach con valutazione foto

### DIFF
--- a/app/lib/features/ai/domain/coach_result.dart
+++ b/app/lib/features/ai/domain/coach_result.dart
@@ -7,6 +7,8 @@ class CoachResult {
     required this.description,
     required this.days,
     this.notes,
+    this.assessment,
+    this.photoReviewWeeks,
   });
 
   final String planName;
@@ -14,14 +16,22 @@ class CoachResult {
   final List<WorkoutDay> days;
   final String? notes;
 
+  /// AI assessment of the current situation/objective from the body photos.
+  final String? assessment;
+
+  /// Suggested number of weeks before re-taking progress photos.
+  final int? photoReviewWeeks;
+
   factory CoachResult.fromJson(Map<String, dynamic> json) {
     return CoachResult(
       planName: (json['plan_name'] ?? '') as String,
       description: (json['description'] ?? '') as String,
       days: ((json['days'] ?? []) as List)
-          .map((d) => WorkoutDay.fromJson(d as Map<String, dynamic>))
+          .map((d) => WorkoutDay.fromJson(Map<String, dynamic>.from(d as Map)))
           .toList(),
       notes: (json['notes'] ?? json['progression_notes']) as String?,
+      assessment: (json['assessment'] ?? json['current_situation']) as String?,
+      photoReviewWeeks: (json['photo_review_weeks'] as num?)?.toInt(),
     );
   }
 

--- a/app/lib/features/ai/presentation/coach_onboarding_screen.dart
+++ b/app/lib/features/ai/presentation/coach_onboarding_screen.dart
@@ -9,6 +9,7 @@ import 'package:fitness_ai/core/theme/app_spacing.dart';
 import 'package:fitness_ai/core/widgets/widgets.dart';
 import 'package:fitness_ai/features/ai/data/ai_repository.dart';
 import 'package:fitness_ai/features/ai/presentation/coach_result_screen.dart';
+import 'package:fitness_ai/features/workout/data/workout_repository.dart';
 import 'package:fitness_ai/features/auth/presentation/auth_notifier.dart';
 import 'package:fitness_ai/features/auth/domain/auth_state.dart';
 
@@ -142,6 +143,7 @@ class _CoachOnboardingScreenState
         photos.add((bytes: _sidePhoto!, filename: 'side.jpg'));
       }
 
+      final known = ref.read(knownExerciseNamesProvider);
       final userData = <String, dynamic>{
         if (int.tryParse(_ageController.text) != null)
           'age': int.parse(_ageController.text),
@@ -149,6 +151,7 @@ class _CoachOnboardingScreenState
         'available_days': _frequency,
         if (_limitationsController.text.trim().isNotEmpty)
           'limitations': _limitationsController.text.trim(),
+        if (known.isNotEmpty) 'known_exercises': known.take(150).toList(),
       };
 
       final aiRepo = ref.read(aiRepositoryProvider);

--- a/app/lib/features/ai/presentation/coach_result_screen.dart
+++ b/app/lib/features/ai/presentation/coach_result_screen.dart
@@ -46,6 +46,48 @@ class CoachResultScreen extends ConsumerWidget {
                       result.description,
                       style: Theme.of(context).textTheme.bodyMedium,
                     ),
+                    if (result.assessment != null &&
+                        result.assessment!.trim().isNotEmpty) ...[
+                      const SizedBox(height: AppSpacing.md),
+                      GlassmorphismCard(
+                        borderColor: AppColors.primary.withValues(alpha: 0.25),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Row(
+                              children: [
+                                Icon(Icons.assignment_ind,
+                                    color: AppColors.primary, size: 18),
+                                SizedBox(width: AppSpacing.sm),
+                                Text('La tua situazione e obiettivo',
+                                    style:
+                                        TextStyle(fontWeight: FontWeight.w700)),
+                              ],
+                            ),
+                            const SizedBox(height: AppSpacing.xs),
+                            Text(result.assessment!,
+                                style: Theme.of(context).textTheme.bodyMedium),
+                          ],
+                        ),
+                      ),
+                    ],
+                    if (result.photoReviewWeeks != null &&
+                        result.photoReviewWeeks! > 0) ...[
+                      const SizedBox(height: AppSpacing.sm),
+                      Row(
+                        children: [
+                          const Icon(Icons.photo_camera,
+                              color: AppColors.warning, size: 18),
+                          const SizedBox(width: AppSpacing.sm),
+                          Expanded(
+                            child: Text(
+                              'Rifai le foto tra ${result.photoReviewWeeks} settimane per valutare i progressi e aggiornare la scheda.',
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                     if (result.notes != null) ...[
                       const SizedBox(height: AppSpacing.sm),
                       GlassmorphismCard(

--- a/app/lib/features/history/data/history_repository.dart
+++ b/app/lib/features/history/data/history_repository.dart
@@ -21,7 +21,7 @@ class HistoryRepository {
     final out = <WorkoutSession>[];
     for (final m in HiveStorage.sessions.values) {
       try {
-        final s = WorkoutSession.fromJson(Map<String, dynamic>.from(m as Map));
+        final s = WorkoutSession.fromJson(Map<String, dynamic>.from(m));
         if (s.isCompleted) out.add(s);
       } catch (_) {
         // skip corrupt/incompatible cached record

--- a/app/lib/features/workout/data/workout_repository.dart
+++ b/app/lib/features/workout/data/workout_repository.dart
@@ -42,7 +42,7 @@ class WorkoutRepository {
     final out = <WorkoutSession>[];
     for (final m in HiveStorage.sessions.values) {
       try {
-        out.add(WorkoutSession.fromJson(Map<String, dynamic>.from(m as Map)));
+        out.add(WorkoutSession.fromJson(Map<String, dynamic>.from(m)));
       } catch (_) {
         // skip corrupt/incompatible cached record
       }
@@ -182,7 +182,7 @@ class WorkoutRepository {
     final out = <WorkoutPlan>[];
     for (final m in HiveStorage.plans.values) {
       try {
-        out.add(WorkoutPlan.fromJson(Map<String, dynamic>.from(m as Map)));
+        out.add(WorkoutPlan.fromJson(Map<String, dynamic>.from(m)));
       } catch (_) {
         // skip corrupt/incompatible cached record
       }
@@ -225,4 +225,31 @@ class WorkoutRepository {
 /// Provider for workout repository.
 final workoutRepositoryProvider = Provider<WorkoutRepository>((ref) {
   return WorkoutRepository(apiClient: ref.watch(apiClientProvider));
+});
+
+/// Known exercise names (from the user's history + the exercises catalog),
+/// deduplicated case-insensitively and sorted. Used to suggest a consistent
+/// name when creating plans / adding exercises, so the same exercise always
+/// gets the same name (pre-fill and charts key on the name).
+final knownExerciseNamesProvider = Provider<List<String>>((ref) {
+  final repo = ref.watch(workoutRepositoryProvider);
+  final seen = <String>{}; // lowercase keys
+  final names = <String>[];
+  void add(String raw) {
+    final name = raw.trim();
+    if (name.isEmpty) return;
+    final key = name.toLowerCase();
+    if (seen.add(key)) names.add(name);
+  }
+
+  for (final s in repo.getAllLocalSessions()) {
+    for (final e in s.exercises) {
+      add(e.exerciseName);
+    }
+  }
+  for (final ex in repo.getCachedExercises()) {
+    add(ex.name);
+  }
+  names.sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+  return names;
 });

--- a/app/lib/features/workout/domain/workout_plan.dart
+++ b/app/lib/features/workout/domain/workout_plan.dart
@@ -88,7 +88,8 @@ class WorkoutDay {
 
   factory WorkoutDay.fromJson(Map<String, dynamic> json) {
     return WorkoutDay(
-      name: json['name'] as String,
+      // Server plans use `name`; AI-coach output uses `day_name`.
+      name: (json['name'] ?? json['day_name'] ?? 'Giorno').toString(),
       exercises: ((json['exercises'] ?? []) as List)
           .map((e) => PlannedExercise.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),

--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -70,24 +70,38 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
   /// Start a new session from a workout day plan.
   /// Pre-fills weights from the last completed session for the same day.
   void startSession(WorkoutDay day, {String? planId}) {
-    // Find previous session for this day to pre-fill weights
-    final allSessions = _repo.getAllLocalSessions();
-    final previousSession = allSessions
-        .where((s) =>
-            s.isCompleted && s.dayName == day.name && s.planId == planId)
+    // Pre-fill weights from the most recent time each exercise was performed,
+    // across the whole history (independent of day name / plan), matching by
+    // exercise name. This keeps pre-fill working even after renaming days or
+    // switching plans.
+    final completed = _repo
+        .getAllLocalSessions() // newest-first
+        .where((s) => s.isCompleted)
         .toList();
-    final previous = previousSession.isNotEmpty ? previousSession.first : null;
+
+    String norm(String s) => s.trim().toLowerCase();
+
+    ExerciseLog? lastExerciseNamed(String name) {
+      final target = norm(name);
+      for (final s in completed) {
+        for (final e in s.exercises) {
+          if (norm(e.exerciseName) == target &&
+              e.sets.any((st) => st.completed && st.weight > 0)) {
+            return e;
+          }
+        }
+      }
+      return null;
+    }
 
     final exercises = day.exercises.map((ep) {
       final repsInt = int.tryParse(ep.reps) ?? 10;
-
-      // Find matching exercise from last session
-      ExerciseLog? prevExercise;
-      if (previous != null) {
-        final matches = previous.exercises
-            .where((e) => e.exerciseName == ep.exerciseName);
-        if (matches.isNotEmpty) prevExercise = matches.first;
-      }
+      final prevExercise = lastExerciseNamed(ep.exerciseName);
+      final lastWeighted = prevExercise == null
+          ? const <SetLog>[]
+          : prevExercise.sets
+              .where((s) => s.completed && s.weight > 0)
+              .toList();
 
       return ExerciseLog(
         exerciseId: ep.exerciseId ?? '',
@@ -95,19 +109,16 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
         exerciseType: ep.exerciseType,
         restSeconds: ep.restSeconds,
         sets: List.generate(ep.sets, (i) {
-          // Pre-fill weight from last session's corresponding set
+          // Use the matching set index if available, otherwise the last
+          // weighted set from that exercise's most recent session.
           double prefillWeight = 0;
-          if (prevExercise != null && i < prevExercise.sets.length) {
-            final prevSet = prevExercise.sets[i];
-            if (prevSet.completed && prevSet.weight > 0) {
-              prefillWeight = prevSet.weight;
-            }
-          } else if (prevExercise != null && prevExercise.sets.isNotEmpty) {
-            // Use last available completed set weight
-            final lastCompleted =
-                prevExercise.sets.where((s) => s.completed && s.weight > 0);
-            if (lastCompleted.isNotEmpty) {
-              prefillWeight = lastCompleted.last.weight;
+          if (prevExercise != null) {
+            if (i < prevExercise.sets.length &&
+                prevExercise.sets[i].completed &&
+                prevExercise.sets[i].weight > 0) {
+              prefillWeight = prevExercise.sets[i].weight;
+            } else if (lastWeighted.isNotEmpty) {
+              prefillWeight = lastWeighted.last.weight;
             }
           }
           return SetLog(

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -10,7 +10,9 @@ import 'package:fitness_ai/core/theme/app_spacing.dart';
 import 'package:fitness_ai/core/widgets/widgets.dart';
 import 'package:fitness_ai/features/workout/domain/exercise_log.dart';
 import 'package:fitness_ai/features/workout/domain/workout_session.dart';
+import 'package:fitness_ai/features/workout/data/workout_repository.dart';
 import 'package:fitness_ai/features/workout/presentation/active_session_notifier.dart';
+import 'package:fitness_ai/features/workout/presentation/exercise_name_field.dart';
 import 'package:fitness_ai/features/workout/presentation/rest_timer_overlay.dart';
 import 'package:fitness_ai/features/workout/presentation/set_input_row.dart';
 
@@ -290,8 +292,10 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
 
   void _showAddExerciseDialog() {
     final nameController = TextEditingController();
+    final nameFocus = FocusNode();
     final setsController = TextEditingController(text: '3');
     final repsController = TextEditingController(text: '10');
+    final known = ref.read(knownExerciseNamesProvider);
 
     showDialog(
       context: context,
@@ -302,11 +306,11 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              TextField(
+              ExerciseNameField(
                 controller: nameController,
-                autofocus: true,
-                textCapitalization: TextCapitalization.sentences,
-                decoration: const InputDecoration(labelText: 'Nome esercizio'),
+                focusNode: nameFocus,
+                known: known,
+                labelText: 'Nome esercizio',
               ),
               const SizedBox(height: AppSpacing.sm),
               Row(

--- a/app/lib/features/workout/presentation/create_plan_screen.dart
+++ b/app/lib/features/workout/presentation/create_plan_screen.dart
@@ -7,13 +7,16 @@ import 'package:fitness_ai/core/widgets/widgets.dart';
 import 'package:fitness_ai/features/workout/data/workout_repository.dart';
 import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
 import 'package:fitness_ai/features/workout/presentation/active_plan_provider.dart';
+import 'package:fitness_ai/features/workout/presentation/exercise_name_field.dart';
 
 class _ExDraft {
   final name = TextEditingController();
+  final nameFocus = FocusNode();
   final sets = TextEditingController(text: '3');
   final reps = TextEditingController(text: '10');
   void dispose() {
     name.dispose();
+    nameFocus.dispose();
     sets.dispose();
     reps.dispose();
   }
@@ -214,9 +217,10 @@ class _CreatePlanScreenState extends ConsumerState<CreatePlanScreen> {
         children: [
           Expanded(
             flex: 5,
-            child: TextField(
+            child: ExerciseNameField(
               controller: ex.name,
-              decoration: const InputDecoration(hintText: 'Esercizio'),
+              focusNode: ex.nameFocus,
+              known: ref.read(knownExerciseNamesProvider),
             ),
           ),
           const SizedBox(width: 6),

--- a/app/lib/features/workout/presentation/exercise_name_field.dart
+++ b/app/lib/features/workout/presentation/exercise_name_field.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+import 'package:fitness_ai/core/theme/app_colors.dart';
+
+/// Text field for an exercise name with autocomplete from known names
+/// (history + catalog), so the same exercise always gets the same name.
+/// Uses the caller's [controller]/[focusNode] so the entered value is read
+/// the usual way (no special wiring needed).
+class ExerciseNameField extends StatelessWidget {
+  const ExerciseNameField({
+    super.key,
+    required this.controller,
+    required this.focusNode,
+    required this.known,
+    this.hintText = 'Esercizio',
+    this.labelText,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final List<String> known;
+  final String hintText;
+  final String? labelText;
+
+  @override
+  Widget build(BuildContext context) {
+    return RawAutocomplete<String>(
+      textEditingController: controller,
+      focusNode: focusNode,
+      optionsBuilder: (TextEditingValue value) {
+        final q = value.text.trim().toLowerCase();
+        if (q.length < 2) return const Iterable<String>.empty();
+        // Prefix matches first, then contains.
+        final starts = <String>[];
+        final contains = <String>[];
+        for (final n in known) {
+          final l = n.toLowerCase();
+          if (l == q) continue; // already exactly typed
+          if (l.startsWith(q)) {
+            starts.add(n);
+          } else if (l.contains(q)) {
+            contains.add(n);
+          }
+        }
+        return [...starts, ...contains].take(8);
+      },
+      fieldViewBuilder: (context, ctrl, fn, onFieldSubmitted) {
+        return TextField(
+          controller: ctrl,
+          focusNode: fn,
+          textCapitalization: TextCapitalization.sentences,
+          onSubmitted: (_) => onFieldSubmitted(),
+          decoration: InputDecoration(
+            hintText: hintText,
+            labelText: labelText,
+          ),
+        );
+      },
+      optionsViewBuilder: (context, onSelected, options) {
+        return Align(
+          alignment: Alignment.topLeft,
+          child: Material(
+            color: AppColors.bgSecondary,
+            elevation: 6,
+            borderRadius: BorderRadius.circular(8),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 220, maxWidth: 320),
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                shrinkWrap: true,
+                itemCount: options.length,
+                itemBuilder: (context, i) {
+                  final opt = options.elementAt(i);
+                  return InkWell(
+                    onTap: () => onSelected(opt),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 10),
+                      child: Text(opt,
+                          style: const TextStyle(
+                              color: AppColors.textPrimary, fontSize: 14)),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/services/ai/app/prompts/coach_generate.py
+++ b/services/ai/app/prompts/coach_generate.py
@@ -15,43 +15,50 @@ Your task is to analyze body photos and user data to create a \
 personalized, structured workout plan.
 
 Rules:
-- Always respond with valid JSON matching the exact schema below
-- Create a realistic, progressive plan appropriate for the user's level and goals
-- Consider any physical limitations mentioned in the user data
-- Each workout day should have 5-8 exercises with specific sets, reps, and rest periods
-- Include warm-up and cool-down notes
-- Suggest starting weights based on typical ranges for the user's apparent fitness level
-- Plans should be 4-6 weeks in duration with progressive overload
+- Always respond with valid JSON matching the exact schema below.
+- ALL user-facing text (plan_name, description, assessment, exercise_name, \
+progression_notes, nutrition_tips, notes) MUST be written in ITALIAN.
+- Analyze the body photos and fill "assessment" (in Italian, 2-4 sentences): \
+describe the user's current physique situation and how this plan addresses \
+their objective. Be honest, concrete and encouraging.
+- Fill "photo_review_weeks": after how many weeks the user should re-take \
+progress photos to reassess (typically 4-8).
+- Create a realistic, progressive plan appropriate for the user's level/goals.
+- Consider any physical limitations mentioned in the user data.
+- Each workout day should have 5-8 exercises with specific sets, reps, rest.
+- Plans should be 4-6 weeks in duration with progressive overload.
+- EXERCISE NAMES: if the user message includes a list of existing exercise \
+names, REUSE the exact same name VERBATIM whenever the exercise matches one of \
+them (same spelling/case). Only invent a new name (clear, standard Italian) \
+when none of the existing names fits. This keeps names consistent over time.
 
 Response JSON schema:
 {
-  "plan_name": "string - descriptive plan name",
-  "description": "string - brief overview of the plan and its goals",
-  "duration_weeks": "integer - plan duration in weeks",
-  "days_per_week": "integer - training days per week",
+  "plan_name": "string - nome scheda (italiano)",
+  "description": "string - panoramica della scheda e dell'obiettivo (italiano)",
+  "assessment": "string - ITALIANO: situazione attuale dalle foto + come la scheda lavora sull'obiettivo (2-4 frasi)",
+  "photo_review_weeks": "integer - tra quante settimane rifare le foto",
+  "duration_weeks": "integer",
+  "days_per_week": "integer",
   "level": "string - beginner|intermediate|advanced",
   "days": [
     {
-      "day_name": "string - e.g. 'Day 1 - Upper Body Push'",
-      "focus": "string - primary muscle groups for this day",
-      "warm_up": "string - warm-up instructions",
+      "day_name": "string - es. 'Giorno 1 - Spinta'",
+      "focus": "string - gruppi muscolari principali",
       "exercises": [
         {
-          "name": "string - exercise name",
-          "name_it": "string - exercise name in Italian",
-          "muscle_groups": ["string - target muscles"],
+          "exercise_name": "string - nome esercizio in ITALIANO (riusa un nome esistente verbatim se combacia)",
+          "muscle_groups": ["string"],
           "sets": "integer",
-          "reps": "string - e.g. '8-12' or '30 seconds'",
-          "rest_seconds": "integer - rest between sets",
-          "weight_suggestion_kg": "float or null - suggested starting weight",
-          "notes": "string or null - form cues or modifications"
+          "reps": "string - es. '8-12'",
+          "rest_seconds": "integer",
+          "notes": "string or null - note tecniche (italiano)"
         }
-      ],
-      "cool_down": "string - cool-down instructions"
+      ]
     }
   ],
-  "progression_notes": "string - how to progress week over week",
-  "nutrition_tips": "string or null - basic nutrition advice if relevant"
+  "progression_notes": "string - come progredire settimana dopo settimana (italiano)",
+  "nutrition_tips": "string or null - consigli nutrizionali (italiano)"
 }"""
 
 
@@ -94,7 +101,20 @@ def build_coach_user_prompt(user_data: dict) -> str:
     if user_data.get("available_equipment"):
         parts.append(f"Available equipment: {user_data['available_equipment']}")
 
+    known = user_data.get("known_exercises")
+    if isinstance(known, list) and known:
+        parts.append("")
+        parts.append(
+            "Existing exercise names — REUSE the exact name verbatim whenever an "
+            "exercise matches one of these; only use a new Italian name if none fits:"
+        )
+        for n in known[:150]:
+            parts.append(f"- {n}")
+
     parts.append("")
-    parts.append("Respond ONLY with valid JSON matching the schema described.")
+    parts.append(
+        "Respond ONLY with valid JSON matching the schema described. "
+        "All user-facing text must be in Italian."
+    )
 
     return "\n".join(parts)

--- a/services/ai/app/prompts/coach_generate.py
+++ b/services/ai/app/prompts/coach_generate.py
@@ -36,7 +36,7 @@ Response JSON schema:
 {
   "plan_name": "string - nome scheda (italiano)",
   "description": "string - panoramica della scheda e dell'obiettivo (italiano)",
-  "assessment": "string - ITALIANO: situazione attuale dalle foto + come la scheda lavora sull'obiettivo (2-4 frasi)",
+  "assessment": "string - ITALIANO: situazione dalle foto + obiettivo (2-4 frasi)",
   "photo_review_weeks": "integer - tra quante settimane rifare le foto",
   "duration_weeks": "integer",
   "days_per_week": "integer",
@@ -47,7 +47,7 @@ Response JSON schema:
       "focus": "string - gruppi muscolari principali",
       "exercises": [
         {
-          "exercise_name": "string - nome esercizio in ITALIANO (riusa un nome esistente verbatim se combacia)",
+          "exercise_name": "string - nome IT (riusa un nome esistente se combacia)",
           "muscle_groups": ["string"],
           "sets": "integer",
           "reps": "string - es. '8-12'",

--- a/services/ai/app/schemas.py
+++ b/services/ai/app/schemas.py
@@ -72,6 +72,8 @@ class CoachGenerateSyncResponse(BaseModel):
 
     plan_name: str
     description: str
+    assessment: str | None = None
+    photo_review_weeks: int | None = None
     duration_weeks: int | None = None
     days_per_week: int | None = None
     level: str | None = None


### PR DESCRIPTION
## Pre-fill pesi (bug: pesi vuoti)
All'avvio allenamento i pesi venivano cercati per **nome-giorno**, ma ho rinominato i giorni (Push/Pull) → nessun match → vuoti. Ora il pre-fill è **per singolo esercizio** (match per nome su tutto lo storico): ti mette l'ultimo peso usato per quell'esercizio.

## Nomi esercizi consistenti
- **Autocomplete** sul nome esercizio (da storico + catalogo) in *Crea scheda* e *Aggiungi esercizio*.
- L'**AI Coach** riceve l'elenco dei nomi esistenti e **riusa il nome esatto** quando combacia (ne crea uno nuovo solo se serve) → stessi nomi nel tempo (pre-fill e grafici restano coerenti).

## AI Coach da foto
- Output con **assessment** (situazione attuale + obiettivo, in italiano) e **photo_review_weeks** (quando rifare le foto), mostrati nella schermata risultato.
- Tutto il testo della scheda in **italiano**.
- Fix parsing: `WorkoutDay.fromJson` accetta `day_name`/`exercise_name` del coach (prima avrebbe crashato al salvataggio).

Backend ai: schema CoachGenerateSyncResponse (+assessment, +photo_review_weeks) + prompt aggiornato. Richiede redeploy ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)