### PR TITLE
feat(app): mostra note esercizio (RIR/tecnica) nell'allenamento

### DIFF
--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -108,6 +108,7 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
         exerciseName: ep.exerciseName,
         exerciseType: ep.exerciseType,
         restSeconds: ep.restSeconds,
+        notes: ep.notes ?? '',
         sets: List.generate(ep.sets, (i) {
           // Use the matching set index if available, otherwise the last
           // weighted set from that exercise's most recent session.

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -481,15 +481,32 @@ class _ExerciseCard extends ConsumerWidget {
             Row(
               children: [
                 Expanded(
-                  child: Text(
-                    exercise.exerciseName,
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          color: exercise.skipped
-                              ? AppColors.textDisabled
-                              : null,
-                          decoration:
-                              exercise.skipped ? TextDecoration.lineThrough : null,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        exercise.exerciseName,
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              color: exercise.skipped
+                                  ? AppColors.textDisabled
+                                  : null,
+                              decoration: exercise.skipped
+                                  ? TextDecoration.lineThrough
+                                  : null,
+                            ),
+                      ),
+                      if (exercise.notes.trim().isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            exercise.notes,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(color: AppColors.textSecondary),
+                          ),
                         ),
+                    ],
                   ),
                 ),
                 // Skip / Unskip


### PR DESCRIPTION
Le note del piano (RIR, tecnica, superset) ora fluiscono in startSession e sono mostrate sotto il nome esercizio nell'allenamento attivo. Necessario per schede tipo Upper/Lower con RIR. Verificato live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)