### PR TITLE
feat: elimina sessione (storico) + rimuovi serie (allenamento)

### DIFF
--- a/app/lib/features/history/data/history_repository.dart
+++ b/app/lib/features/history/data/history_repository.dart
@@ -31,6 +31,18 @@ class HistoryRepository {
     return out;
   }
 
+  /// Delete a session from the local cache and (best-effort) from the server.
+  /// Sessions that exist only locally (never synced) just get removed locally;
+  /// a 404/connection error from the server is ignored.
+  Future<void> deleteSession(String id) async {
+    await HiveStorage.sessions.delete(id);
+    try {
+      await apiClient.delete('${ApiConstants.workoutSessions}/$id');
+    } on DioException {
+      // Local-only session or already gone server-side: nothing else to do.
+    }
+  }
+
   /// Fetch sessions from API and cache locally.
   Future<List<WorkoutSession>> fetchSessions({
     DateTime? from,

--- a/app/lib/features/history/presentation/history_screen.dart
+++ b/app/lib/features/history/presentation/history_screen.dart
@@ -35,6 +35,41 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     });
   }
 
+  Future<bool> _confirmDelete(WorkoutSession session) async {
+    final res = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.bgSecondary,
+        title: const Text('Eliminare la sessione?'),
+        content: Text(
+            '${session.dayName ?? 'Workout'} verrà rimossa dallo storico.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Annulla'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Elimina',
+                style: TextStyle(color: AppColors.error)),
+          ),
+        ],
+      ),
+    );
+    return res ?? false;
+  }
+
+  Future<void> _deleteSession(WorkoutSession session) async {
+    // Remove from the in-memory list first so the Dismissible is consistent.
+    setState(() =>
+        _sessions = _sessions.where((s) => s.id != session.id).toList());
+    final messenger = ScaffoldMessenger.of(context);
+    await ref.read(historyRepositoryProvider).deleteSession(session.id);
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Sessione eliminata')),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final dateFormat = DateFormat('d MMM yyyy', 'it');
@@ -90,7 +125,26 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                           itemCount: _sessions.length,
                           itemBuilder: (context, index) {
                             final session = _sessions[index];
-                            return StaggeredListItem(
+                            return Dismissible(
+                              key: ValueKey(session.id),
+                              direction: DismissDirection.endToStart,
+                              confirmDismiss: (_) => _confirmDelete(session),
+                              onDismissed: (_) => _deleteSession(session),
+                              background: Container(
+                                alignment: Alignment.centerRight,
+                                padding: const EdgeInsets.only(
+                                    right: AppSpacing.lg),
+                                margin: const EdgeInsets.symmetric(
+                                    vertical: AppSpacing.xs),
+                                decoration: BoxDecoration(
+                                  color: AppColors.error.withValues(alpha: 0.15),
+                                  borderRadius: BorderRadius.circular(
+                                      AppSpacing.radiusMd),
+                                ),
+                                child: const Icon(Icons.delete_outline,
+                                    color: AppColors.error),
+                              ),
+                              child: StaggeredListItem(
                               index: index,
                               child: GlassmorphismCard(
                                 onTap: () {
@@ -172,6 +226,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                                   ],
                                 ),
                               ),
+                            ),
                             );
                           },
                         ),

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -576,6 +576,20 @@ class _ExerciseCard extends ConsumerWidget {
                       foregroundColor: AppColors.primary,
                     ),
                   ),
+                  if (exercise.sets.length > 1)
+                    TextButton.icon(
+                      onPressed: () => ref
+                          .read(activeSessionProvider.notifier)
+                          .removeSet(
+                            exerciseIndex: exerciseIndex,
+                            setIndex: exercise.sets.length - 1,
+                          ),
+                      icon: const Icon(Icons.remove, size: 16),
+                      label: const Text('Rimuovi'),
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColors.textSecondary,
+                      ),
+                    ),
                 ],
               ),
             ],

--- a/services/workouts/app/router.py
+++ b/services/workouts/app/router.py
@@ -26,6 +26,7 @@ from app.schemas import (
 from app.service import (
     DuplicateClientIdError,
     PlanNotFoundError,
+    SessionNotFoundError,
     WorkoutService,
 )
 
@@ -242,6 +243,26 @@ async def create_session(
     except DuplicateClientIdError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.message) from exc
     return SessionResponse.model_validate(session)
+
+
+@router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: uuid.UUID,
+    user_id: uuid.UUID = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a workout session owned by the authenticated user.
+
+    Args:
+        session_id: Session UUID.
+        user_id: Authenticated user UUID from JWT.
+        db: Database session.
+    """
+    service = WorkoutService(db)
+    try:
+        await service.delete_session(session_id, user_id)
+    except SessionNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.message) from exc
 
 
 # ============================================================

--- a/services/workouts/app/service.py
+++ b/services/workouts/app/service.py
@@ -287,6 +287,28 @@ class WorkoutService:
         sessions = list(result.scalars().all())
         return sessions, total
 
+    async def delete_session(self, session_id: uuid.UUID, user_id: uuid.UUID) -> None:
+        """Delete a workout session owned by the user.
+
+        Args:
+            session_id: Session UUID.
+            user_id: Owner user UUID.
+
+        Raises:
+            SessionNotFoundError: If the session does not exist or is not owned.
+        """
+        result = await self.db.execute(
+            select(WorkoutSession).where(
+                WorkoutSession.id == session_id,
+                WorkoutSession.user_id == user_id,
+            )
+        )
+        session = result.scalar_one_or_none()
+        if not session:
+            raise SessionNotFoundError()
+        await self.db.delete(session)
+        await self.db.commit()
+
     # ============================================================
     # Sync
     # ============================================================

--- a/services/workouts/tests/test_sessions.py
+++ b/services/workouts/tests/test_sessions.py
@@ -210,3 +210,42 @@ async def test_sync_sessions_duplicate(client: AsyncClient, auth_headers: dict):
     response = await client.post("/workouts/sync", json=payload, headers=auth_headers)
     assert response.status_code == 200
     assert response.json()["results"][0]["status"] == "duplicate"
+
+
+@pytest.mark.asyncio
+async def test_delete_session_success(client: AsyncClient, auth_headers: dict):
+    """Deleting an owned session returns 204 and removes it from the list."""
+    created = await client.post(
+        "/workouts/sessions", json=make_session_data(), headers=auth_headers
+    )
+    session_id = created.json()["id"]
+
+    resp = await client.delete(f"/workouts/sessions/{session_id}", headers=auth_headers)
+    assert resp.status_code == 204
+
+    listed = await client.get("/workouts/sessions", headers=auth_headers)
+    assert listed.json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_session_not_found(client: AsyncClient, auth_headers: dict):
+    """Deleting a non-existent session returns 404."""
+    resp = await client.delete(
+        f"/workouts/sessions/{uuid.uuid4()}", headers=auth_headers
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_session_other_user(client: AsyncClient, auth_headers: dict):
+    """A user cannot delete another user's session."""
+    from tests.conftest import create_test_token
+
+    created = await client.post(
+        "/workouts/sessions", json=make_session_data(), headers=auth_headers
+    )
+    session_id = created.json()["id"]
+
+    other = {"Authorization": f"Bearer {create_test_token(str(uuid.uuid4()))}"}
+    resp = await client.delete(f"/workouts/sessions/{session_id}", headers=other)
+    assert resp.status_code == 404

--- a/services/workouts/tests/test_sessions.py
+++ b/services/workouts/tests/test_sessions.py
@@ -230,9 +230,7 @@ async def test_delete_session_success(client: AsyncClient, auth_headers: dict):
 @pytest.mark.asyncio
 async def test_delete_session_not_found(client: AsyncClient, auth_headers: dict):
     """Deleting a non-existent session returns 404."""
-    resp = await client.delete(
-        f"/workouts/sessions/{uuid.uuid4()}", headers=auth_headers
-    )
+    resp = await client.delete(f"/workouts/sessions/{uuid.uuid4()}", headers=auth_headers)
     assert resp.status_code == 404
 
 


### PR DESCRIPTION
## Elimina sessione
- Backend: **DELETE /workouts/sessions/{id}** (service + router + test).
- **Storico**: swipe-to-delete con conferma. `deleteSession` rimuove dalla cache locale (Hive) + best-effort dal server (404 ignorato per sessioni mai sincronizzate). Risolve la sessione vuota salvata per sbaglio.

## Rimuovi serie
- Allenamento attivo: pulsante **Rimuovi** accanto a **Aggiungi serie** (minimo 1 serie). Prima si poteva solo aggiungere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)