### PR TITLE
feat(app): selettore esercizi con ricerca (Aggiungi esercizio)

### DIFF
--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -243,7 +243,7 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
                   final exIndex = index - warmupOffset;
                   if (exIndex == session.exercises.length) {
                     return _AddExerciseButton(
-                      onAdd: () => _showAddExerciseDialog(),
+                      onAdd: _addExercise,
                     );
                   }
                   return _ExerciseCard(
@@ -290,85 +290,17 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
     );
   }
 
-  void _showAddExerciseDialog() {
-    final nameController = TextEditingController();
-    final nameFocus = FocusNode();
-    final setsController = TextEditingController(text: '3');
-    final repsController = TextEditingController(text: '10');
+  Future<void> _addExercise() async {
+    // Pick from existing exercises (consistent names) or create a new one
+    // explicitly — avoids typing a slightly different name by mistake.
     final known = ref.read(knownExerciseNamesProvider);
-
-    showDialog(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: AppColors.bgSecondary,
-        title: const Text('Aggiungi esercizio'),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              ExerciseNameField(
-                controller: nameController,
-                focusNode: nameFocus,
-                known: known,
-                labelText: 'Nome esercizio',
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: setsController,
-                      keyboardType: TextInputType.number,
-                      onTap: () => setsController.selection = TextSelection(
-                          baseOffset: 0,
-                          extentOffset: setsController.text.length),
-                      decoration: const InputDecoration(labelText: 'Serie'),
-                    ),
-                  ),
-                  const SizedBox(width: AppSpacing.sm),
-                  Expanded(
-                    child: TextField(
-                      controller: repsController,
-                      keyboardType: TextInputType.number,
-                      onTap: () => repsController.selection = TextSelection(
-                          baseOffset: 0,
-                          extentOffset: repsController.text.length),
-                      decoration: const InputDecoration(labelText: 'Reps'),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              const Text(
-                'Potrai aggiungere altre serie con "+ Serie" durante l\'esercizio.',
-                style: TextStyle(
-                    color: AppColors.textSecondary, fontSize: 12),
-              ),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Annulla'),
-          ),
-          TextButton(
-            onPressed: () {
-              if (nameController.text.trim().isNotEmpty) {
-                ref.read(activeSessionProvider.notifier).addCustomExercise(
-                      name: nameController.text.trim(),
-                      sets: int.tryParse(setsController.text) ?? 3,
-                      reps: int.tryParse(repsController.text) ?? 10,
-                    );
-              }
-              Navigator.of(ctx).pop();
-            },
-            child: const Text('Aggiungi',
-                style: TextStyle(color: AppColors.primary)),
-          ),
-        ],
-      ),
-    );
+    final name = await showExercisePicker(context, known);
+    if (name == null || name.trim().isEmpty) return;
+    ref.read(activeSessionProvider.notifier).addCustomExercise(
+          name: name.trim(),
+          sets: 3,
+          reps: 10,
+        );
   }
 }
 

--- a/app/lib/features/workout/presentation/exercise_name_field.dart
+++ b/app/lib/features/workout/presentation/exercise_name_field.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:fitness_ai/core/theme/app_colors.dart';
+import 'package:fitness_ai/core/theme/app_spacing.dart';
 
 /// Text field for an exercise name with autocomplete from known names
 /// (history + catalog), so the same exercise always gets the same name.
@@ -87,6 +88,121 @@ class ExerciseNameField extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// Bottom-sheet picker to choose an exercise by name. Shows the known
+/// exercises (history + catalog) filtered by search so the SAME name is always
+/// reused; creating a brand-new name is an explicit action shown only when the
+/// typed text doesn't already match a known exercise. Returns the chosen name
+/// (existing or new) or null if cancelled.
+Future<String?> showExercisePicker(
+    BuildContext context, List<String> known) {
+  return showModalBottomSheet<String>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: AppColors.bgSecondary,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (ctx) => _ExercisePicker(known: known),
+  );
+}
+
+class _ExercisePicker extends StatefulWidget {
+  const _ExercisePicker({required this.known});
+  final List<String> known;
+
+  @override
+  State<_ExercisePicker> createState() => _ExercisePickerState();
+}
+
+class _ExercisePickerState extends State<_ExercisePicker> {
+  final _ctrl = TextEditingController();
+  String _q = '';
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final q = _q.trim().toLowerCase();
+    final matches = q.isEmpty
+        ? widget.known
+        : widget.known.where((n) => n.toLowerCase().contains(q)).toList();
+    final exact = widget.known.any((n) => n.toLowerCase() == q);
+    final typed = _ctrl.text.trim();
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: SizedBox(
+        height: MediaQuery.of(context).size.height * 0.78,
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: Column(
+                children: [
+                  Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: AppColors.textDisabled,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  TextField(
+                    controller: _ctrl,
+                    autofocus: true,
+                    textCapitalization: TextCapitalization.sentences,
+                    decoration: const InputDecoration(
+                      hintText: 'Cerca un esercizio',
+                      prefixIcon: Icon(Icons.search),
+                    ),
+                    onChanged: (v) => setState(() => _q = v),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.only(bottom: AppSpacing.lg),
+                children: [
+                  if (typed.isNotEmpty && !exact)
+                    ListTile(
+                      leading: const Icon(Icons.add_circle_outline,
+                          color: AppColors.primary),
+                      title: Text('Crea nuovo: «$typed»',
+                          style: const TextStyle(color: AppColors.primary)),
+                      subtitle: const Text(
+                          'Solo se non è già nell\'elenco qui sotto'),
+                      onTap: () => Navigator.pop(context, typed),
+                    ),
+                  ...matches.map((n) => ListTile(
+                        leading: const Icon(Icons.fitness_center,
+                            size: 20, color: AppColors.textSecondary),
+                        title: Text(n),
+                        onTap: () => Navigator.pop(context, n),
+                      )),
+                  if (matches.isEmpty && typed.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.all(AppSpacing.lg),
+                      child: Center(
+                        child: Text('Inizia a scrivere per cercare',
+                            style: TextStyle(color: AppColors.textSecondary)),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
"Aggiungi esercizio" ora apre un **bottom sheet con ricerca** sull'elenco degli esercizi noti (storico + catalogo). Si seleziona un nome esistente (sempre identico → pre-fill e grafici coerenti); **"Crea nuovo"** compare solo se il testo non corrisponde a un esercizio esistente. Evita nomi simili-ma-diversi creati per errore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)