### PR TITLE
fix: usabilità allenamento (timer stabile, conferma FINE, tipi esercizio, info scheda)

### DIFF
--- a/app/lib/features/ai/presentation/coach_result_screen.dart
+++ b/app/lib/features/ai/presentation/coach_result_screen.dart
@@ -134,10 +134,26 @@ class CoachResultScreen extends ConsumerWidget {
                     onPressed: () async {
                       final messenger = ScaffoldMessenger.of(context);
                       final navigator = Navigator.of(context);
+                      // Persist the AI explanation (situation/objective +
+                      // overview + progression) on the plan so it can be read
+                      // again later from the workout screen.
+                      final desc = [
+                        if (result.assessment != null &&
+                            result.assessment!.trim().isNotEmpty)
+                          result.assessment!.trim(),
+                        if (result.description.trim().isNotEmpty)
+                          result.description.trim(),
+                        if (result.notes != null && result.notes!.trim().isNotEmpty)
+                          'Progressione: ${result.notes!.trim()}',
+                        if (result.photoReviewWeeks != null &&
+                            result.photoReviewWeeks! > 0)
+                          'Rifai le foto tra ${result.photoReviewWeeks} settimane.',
+                      ].join('\n\n');
                       try {
                         await ref.read(workoutRepositoryProvider).createPlan(
                               name: result.planName,
                               days: result.days,
+                              description: desc.isEmpty ? null : desc,
                             );
                         ref.invalidate(activePlanProvider);
                         messenger.showSnackBar(const SnackBar(

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -59,10 +59,37 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
     }
   }
 
-  void _finishWorkout() {
-    final notifier = ref.read(activeSessionProvider.notifier);
-    notifier.completeSession();
+  Future<void> _finishWorkout() async {
+    // Confirm first: finishing is final (can't be resumed), so guard against
+    // an accidental tap on FINE.
+    final state = ref.read(activeSessionProvider);
+    final done = state?.completedExercises ?? 0;
+    final total = state?.totalExercises ?? 0;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.bgSecondary,
+        title: const Text('Terminare l\'allenamento?'),
+        content: Text(
+            'Hai completato $done/$total esercizi. Una volta terminato non '
+            'potrai riprenderlo.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Continua'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Termina',
+                style: TextStyle(
+                    color: AppColors.success, fontWeight: FontWeight.w700)),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
 
+    ref.read(activeSessionProvider.notifier).completeSession();
     // Show rating dialog first, then completion screen
     _showRatingDialog();
   }
@@ -470,7 +497,9 @@ class _ExerciseCard extends ConsumerWidget {
                 child: Row(
                   children: [
                     const SizedBox(width: 32, child: Text('SET', style: _headerStyle)),
-                    if (exercise.exerciseType == 'weighted') ...[
+                    if (exercise.exerciseType == 'cardio') ...[
+                      const Expanded(child: SizedBox()),
+                    ] else if (exercise.exerciseType == 'weighted') ...[
                       const Expanded(child: Text('KG', style: _headerStyle, textAlign: TextAlign.center)),
                       const Expanded(child: Text('REPS', style: _headerStyle, textAlign: TextAlign.center)),
                     ] else if (exercise.exerciseType == 'timed') ...[

--- a/app/lib/features/workout/presentation/rest_timer_overlay.dart
+++ b/app/lib/features/workout/presentation/rest_timer_overlay.dart
@@ -59,41 +59,31 @@ class RestTimerBar extends StatelessWidget {
                 children: [
                   Icon(Icons.timer_outlined, color: accent, size: 20),
                   const SizedBox(width: AppSpacing.sm),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          'RECUPERO',
-                          style: TextStyle(
-                            color: AppColors.textSecondary,
-                            fontSize: 11,
-                            fontWeight: FontWeight.w700,
-                            letterSpacing: 1.5,
-                          ),
-                        ),
-                        if (exerciseName != null && currentSet != null)
-                          Text(
-                            'Serie $currentSet/$totalSets · $exerciseName',
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              color: AppColors.primary,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(width: AppSpacing.sm),
+                  // Fixed-width countdown (mm:ss) so the row height never jumps.
                   Text(
                     timer.formattedTime,
                     style: TextStyle(
-                      fontSize: 26,
+                      fontSize: 22,
                       fontWeight: FontWeight.w900,
                       color:
                           danger ? AppColors.warning : AppColors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.md),
+                  // Single, non-wrapping label (truncates instead of wrapping).
+                  Expanded(
+                    child: Text(
+                      exerciseName != null && currentSet != null
+                          ? 'Recupero · Serie $currentSet/$totalSets'
+                          : 'Recupero',
+                      maxLines: 1,
+                      softWrap: false,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
                   const SizedBox(width: AppSpacing.sm),

--- a/app/lib/features/workout/presentation/set_input_row.dart
+++ b/app/lib/features/workout/presentation/set_input_row.dart
@@ -107,6 +107,14 @@ class _SetInputRowState extends ConsumerState<SetInputRow> {
           reps: reps,
         );
         break;
+      case 'cardio':
+        // No metrics to log — just mark the set complete.
+        notifier.logBodyweightSet(
+          exerciseIndex: widget.exerciseIndex,
+          setIndex: widget.setIndex,
+          reps: 0,
+        );
+        break;
     }
 
     widget.onCompleted();
@@ -153,7 +161,21 @@ class _SetInputRowState extends ConsumerState<SetInputRow> {
             ),
           ),
           // Input fields based on exercise type
-          if (widget.exerciseType == 'weighted') ...[
+          if (widget.exerciseType == 'cardio') ...[
+            // Cardio: no weight/reps — details are in the exercise note; just
+            // mark it done.
+            Expanded(
+              child: Center(
+                child: Text(
+                  isCompleted ? 'Completato' : 'Segna come fatto',
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                  ),
+                ),
+              ),
+            ),
+          ] else if (widget.exerciseType == 'weighted') ...[
             Expanded(
               child: _CompactInput(
                 controller: _weightController,

--- a/app/lib/features/workout/presentation/workout_home_screen.dart
+++ b/app/lib/features/workout/presentation/workout_home_screen.dart
@@ -92,6 +92,11 @@ class _PlanView extends ConsumerWidget {
           style: Theme.of(context).textTheme.bodyMedium,
         ),
         const SizedBox(height: AppSpacing.md),
+        if (plan.description != null && plan.description!.trim().isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.md),
+            child: _PlanInfoCard(text: plan.description!.trim()),
+          ),
         Expanded(
           child: ListView.separated(
             itemCount: plan.days.length,
@@ -303,6 +308,59 @@ class _AiCard extends StatelessWidget {
                 ),
               ],
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Collapsible card showing the plan description / AI coach explanation
+/// (current situation, objective, progression). Persisted on the plan.
+class _PlanInfoCard extends StatefulWidget {
+  const _PlanInfoCard({required this.text});
+  final String text;
+
+  @override
+  State<_PlanInfoCard> createState() => _PlanInfoCardState();
+}
+
+class _PlanInfoCardState extends State<_PlanInfoCard> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassmorphismCard(
+      onTap: () => setState(() => _expanded = !_expanded),
+      padding: const EdgeInsets.all(AppSpacing.md),
+      borderColor: AppColors.primary.withValues(alpha: 0.25),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.auto_awesome, color: AppColors.primary, size: 18),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Text('Info scheda',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleSmall
+                        ?.copyWith(fontWeight: FontWeight.w700)),
+              ),
+              Icon(_expanded ? Icons.expand_less : Icons.expand_more,
+                  color: AppColors.textSecondary),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            widget.text,
+            maxLines: _expanded ? null : 2,
+            overflow: _expanded ? null : TextOverflow.ellipsis,
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: AppColors.textSecondary),
           ),
         ],
       ),

--- a/services/workouts/app/schemas.py
+++ b/services/workouts/app/schemas.py
@@ -21,6 +21,7 @@ class ExerciseInDay(BaseModel):
     reps: str | None = None
     rest_seconds: int | None = Field(None, ge=0, le=600)
     notes: str | None = None
+    exercise_type: str | None = None
 
 
 class WorkoutDay(BaseModel):


### PR DESCRIPTION
Dai feedback d'uso reale:
- **Cronometro recupero** non salta più (layout a riga fissa, etichetta non va a capo).
- **FINE** chiede conferma (evita di chiudere per sbaglio una sessione non riprendibile).
- **Tipi di esercizio**: `exercise_type` nel piano (backend) + tipo **cardio** (solo "fatto", niente kg/reps assurdi su tapis roulant).
- **Coach da foto**: la spiegazione (situazione/obiettivo/progressione) ora è **salvata** nella scheda e leggibile nella card **Info scheda** (home).

Resta da fare (a parte): raggruppare visivamente i superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)