### PR TITLE
feat: raggruppamento superset nell'allenamento

### DIFF
--- a/app/lib/features/workout/domain/exercise_log.dart
+++ b/app/lib/features/workout/domain/exercise_log.dart
@@ -11,6 +11,7 @@ class ExerciseLog {
     this.restSeconds = 90,
     this.skipped = false,
     this.notes = '',
+    this.supersetGroup,
   });
 
   final String exerciseId;
@@ -22,6 +23,10 @@ class ExerciseLog {
   final bool skipped;
   final String notes;
 
+  /// Superset group id: consecutive exercises sharing a non-null value are
+  /// performed back-to-back and shown grouped together.
+  final String? supersetGroup;
+
   ExerciseLog copyWith({
     String? exerciseId,
     String? exerciseName,
@@ -31,6 +36,7 @@ class ExerciseLog {
     List<SetLog>? sets,
     bool? skipped,
     String? notes,
+    String? supersetGroup,
   }) {
     return ExerciseLog(
       exerciseId: exerciseId ?? this.exerciseId,
@@ -41,6 +47,7 @@ class ExerciseLog {
       sets: sets ?? this.sets,
       skipped: skipped ?? this.skipped,
       notes: notes ?? this.notes,
+      supersetGroup: supersetGroup ?? this.supersetGroup,
     );
   }
 
@@ -68,6 +75,8 @@ class ExerciseLog {
           .toList(),
       skipped: (json['skipped'] ?? false) as bool,
       notes: (json['notes'] ?? '') as String,
+      supersetGroup:
+          (json['superset_group'] ?? json['supersetGroup']) as String?,
     );
   }
 
@@ -80,6 +89,7 @@ class ExerciseLog {
         'sets': sets.map((s) => s.toJson()).toList(),
         'skipped': skipped,
         'notes': notes,
+        'superset_group': supersetGroup,
       };
 
   /// API format for creating sessions.

--- a/app/lib/features/workout/domain/workout_plan.dart
+++ b/app/lib/features/workout/domain/workout_plan.dart
@@ -114,6 +114,7 @@ class PlannedExercise {
     this.restSeconds = 90,
     this.exerciseType = 'weighted',
     this.notes,
+    this.supersetGroup,
   });
 
   final String? exerciseId;
@@ -124,6 +125,10 @@ class PlannedExercise {
   final String exerciseType;
   final String? notes;
 
+  /// Superset group id: consecutive exercises with the same value are a
+  /// superset (performed back-to-back, shown grouped).
+  final String? supersetGroup;
+
   factory PlannedExercise.fromJson(Map<String, dynamic> json) {
     return PlannedExercise(
       exerciseId: json['exercise_id']?.toString(),
@@ -133,6 +138,8 @@ class PlannedExercise {
       restSeconds: (json['rest_seconds'] ?? 90) as int,
       exerciseType: (json['exercise_type'] ?? 'weighted') as String,
       notes: json['notes'] as String?,
+      supersetGroup:
+          (json['superset_group'] ?? json['supersetGroup']) as String?,
     );
   }
 
@@ -144,5 +151,6 @@ class PlannedExercise {
         'rest_seconds': restSeconds,
         'exercise_type': exerciseType,
         'notes': notes,
+        'superset_group': supersetGroup,
       };
 }

--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -109,6 +109,7 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
         exerciseType: ep.exerciseType,
         restSeconds: ep.restSeconds,
         notes: ep.notes ?? '',
+        supersetGroup: ep.supersetGroup,
         sets: List.generate(ep.sets, (i) {
           // Use the matching set index if available, otherwise the last
           // weighted set from that exercise's most recent session.

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -201,6 +201,20 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
     final hasWarmup = sessionState.warmup.isNotEmpty;
     final warmupOffset = hasWarmup ? 1 : 0;
 
+    // Group consecutive exercises sharing a superset id so they render together.
+    final groups = <List<int>>[];
+    String? lastGroup;
+    for (var i = 0; i < session.exercises.length; i++) {
+      final g = session.exercises[i].supersetGroup;
+      final gid = (g != null && g.trim().isNotEmpty) ? g.trim() : null;
+      if (gid != null && gid == lastGroup && groups.isNotEmpty) {
+        groups.last.add(i);
+      } else {
+        groups.add([i]);
+      }
+      lastGroup = gid;
+    }
+
     return Scaffold(
       body: SafeArea(
         child: Column(
@@ -262,21 +276,34 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
               child: ListView.builder(
                 padding:
                     const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-                itemCount: session.exercises.length + 1 + warmupOffset,
+                itemCount: groups.length + 1 + warmupOffset,
                 itemBuilder: (context, index) {
                   if (hasWarmup && index == 0) {
                     return const _WarmupChecklist();
                   }
-                  final exIndex = index - warmupOffset;
-                  if (exIndex == session.exercises.length) {
+                  final gIndex = index - warmupOffset;
+                  if (gIndex == groups.length) {
                     return _AddExerciseButton(
                       onAdd: _addExercise,
                     );
                   }
-                  return _ExerciseCard(
-                    exercise: session.exercises[exIndex],
-                    exerciseIndex: exIndex,
-                    onSetCompleted: (setIndex) => _onSetCompleted(
+                  final group = groups[gIndex];
+                  if (group.length == 1) {
+                    final exIndex = group.first;
+                    return _ExerciseCard(
+                      exercise: session.exercises[exIndex],
+                      exerciseIndex: exIndex,
+                      onSetCompleted: (setIndex) => _onSetCompleted(
+                        session.exercises[exIndex],
+                        exIndex,
+                        setIndex,
+                      ),
+                    );
+                  }
+                  return _SupersetCard(
+                    exercises: [for (final i in group) session.exercises[i]],
+                    indices: group,
+                    onSetCompleted: (exIndex, setIndex) => _onSetCompleted(
                       session.exercises[exIndex],
                       exIndex,
                       setIndex,
@@ -410,9 +437,10 @@ class _CompletionDialogState extends State<_CompletionDialog> {
   }
 }
 
-/// Card for a single exercise showing all its sets inline.
-class _ExerciseCard extends ConsumerWidget {
-  const _ExerciseCard({
+/// The inner content of one exercise (header + set rows + controls).
+/// Reused standalone (in [_ExerciseCard]) and grouped (in [_SupersetCard]).
+class _ExerciseBody extends ConsumerWidget {
+  const _ExerciseBody({
     required this.exercise,
     required this.exerciseIndex,
     required this.onSetCompleted,
@@ -424,16 +452,7 @@ class _ExerciseCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return StaggeredListItem(
-      index: exerciseIndex,
-      child: GlassmorphismCard(
-        margin: const EdgeInsets.only(bottom: AppSpacing.sm),
-        borderColor: exercise.isComplete
-            ? AppColors.success.withValues(alpha: 0.3)
-            : exercise.skipped
-                ? AppColors.textDisabled.withValues(alpha: 0.2)
-                : AppColors.primary.withValues(alpha: 0.1),
-        child: Column(
+    return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Exercise header
@@ -552,6 +571,111 @@ class _ExerciseCard extends ConsumerWidget {
                       ),
                     ),
                 ],
+              ),
+            ],
+          ],
+        );
+  }
+}
+
+/// Card for a single exercise showing all its sets inline.
+class _ExerciseCard extends StatelessWidget {
+  const _ExerciseCard({
+    required this.exercise,
+    required this.exerciseIndex,
+    required this.onSetCompleted,
+  });
+
+  final ExerciseLog exercise;
+  final int exerciseIndex;
+  final void Function(int setIndex) onSetCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    return StaggeredListItem(
+      index: exerciseIndex,
+      child: GlassmorphismCard(
+        margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+        borderColor: exercise.isComplete
+            ? AppColors.success.withValues(alpha: 0.3)
+            : exercise.skipped
+                ? AppColors.textDisabled.withValues(alpha: 0.2)
+                : AppColors.primary.withValues(alpha: 0.1),
+        child: _ExerciseBody(
+          exercise: exercise,
+          exerciseIndex: exerciseIndex,
+          onSetCompleted: onSetCompleted,
+        ),
+      ),
+    );
+  }
+}
+
+/// Card grouping a superset: two or more exercises performed back-to-back.
+class _SupersetCard extends StatelessWidget {
+  const _SupersetCard({
+    required this.exercises,
+    required this.indices,
+    required this.onSetCompleted,
+  });
+
+  final List<ExerciseLog> exercises;
+  final List<int> indices;
+  final void Function(int exerciseIndex, int setIndex) onSetCompleted;
+
+  @override
+  Widget build(BuildContext context) {
+    final allDone = exercises.every((e) => e.isComplete || e.skipped);
+    return StaggeredListItem(
+      index: indices.first,
+      child: GlassmorphismCard(
+        margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+        borderColor: allDone
+            ? AppColors.success.withValues(alpha: 0.3)
+            : AppColors.warning.withValues(alpha: 0.4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.bolt, color: AppColors.warning, size: 18),
+                const SizedBox(width: AppSpacing.xs),
+                const Text(
+                  'SUPERSET',
+                  style: TextStyle(
+                    color: AppColors.warning,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 1.5,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    'esegui di fila, recupero alla fine del giro',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: AppColors.textSecondary),
+                  ),
+                ),
+              ],
+            ),
+            for (int j = 0; j < exercises.length; j++) ...[
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                child: Divider(
+                  color: AppColors.textDisabled.withValues(alpha: 0.2),
+                  height: 1,
+                ),
+              ),
+              _ExerciseBody(
+                exercise: exercises[j],
+                exerciseIndex: indices[j],
+                onSetCompleted: (setIndex) =>
+                    onSetCompleted(indices[j], setIndex),
               ),
             ],
           ],

--- a/services/workouts/app/schemas.py
+++ b/services/workouts/app/schemas.py
@@ -22,6 +22,7 @@ class ExerciseInDay(BaseModel):
     rest_seconds: int | None = Field(None, ge=0, le=600)
     notes: str | None = None
     exercise_type: str | None = None
+    superset_group: str | None = None
 
 
 class WorkoutDay(BaseModel):


### PR DESCRIPTION
Esercizi consecutivi con lo stesso `superset_group` ora sono mostrati in **un'unica card "SUPERSET"** (esercizi A/B insieme con le rispettive serie), invece di card separate con la nota testuale. Campo `superset_group` aggiunto a backend + PlannedExercise + ExerciseLog. Refactor: `_ExerciseBody` riusato da `_ExerciseCard` e `_SupersetCard`.

Dopo il merge: re-PATCH della scheda per marcare le coppie come superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)