### PR TITLE
fix: durata allenamento ripreso, layout home, persistenza modifiche

### DIFF
--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -14,11 +14,16 @@ class ActiveSessionState {
     this.isCompleted = false,
     this.warmup = const [],
     this.warmupChecked = const [],
+    this.resumed = false,
   });
 
   final WorkoutSession session;
   final int currentExerciseIndex;
   final bool isCompleted;
+
+  /// True when this session was reopened from history (resume). The original
+  /// duration is preserved instead of recomputing from the start time.
+  final bool resumed;
 
   /// Warmup items for this day (their text labels).
   final List<String> warmup;
@@ -49,6 +54,7 @@ class ActiveSessionState {
     bool? isCompleted,
     List<String>? warmup,
     List<bool>? warmupChecked,
+    bool? resumed,
   }) {
     return ActiveSessionState(
       session: session ?? this.session,
@@ -56,6 +62,7 @@ class ActiveSessionState {
       isCompleted: isCompleted ?? this.isCompleted,
       warmup: warmup ?? this.warmup,
       warmupChecked: warmupChecked ?? this.warmupChecked,
+      resumed: resumed ?? this.resumed,
     );
   }
 }
@@ -356,7 +363,13 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
     final s = state;
     if (s == null) return;
 
-    final duration = DateTime.now().difference(s.session.startedAt).inSeconds;
+    // For a resumed session we keep the original duration (the user is just
+    // correcting/adding to a past workout, not training again from the original
+    // start time — recomputing now - startedAt would give absurd values like 60h).
+    final elapsed = DateTime.now().difference(s.session.startedAt).inSeconds;
+    final duration = s.resumed
+        ? (s.session.durationSeconds ?? elapsed)
+        : elapsed;
     state = s.copyWith(
       session: s.session.copyWith(
         completedAt: DateTime.now(),
@@ -407,7 +420,9 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
       dayName: session.dayName,
       startedAt: session.startedAt,
       completedAt: null,
-      durationSeconds: null,
+      // Keep the original duration so re-completing doesn't recompute an absurd
+      // value from the original start time (see completeSession).
+      durationSeconds: session.durationSeconds,
       exercises: session.exercises,
       notes: session.notes,
       synced: false,
@@ -417,6 +432,7 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
     );
     state = ActiveSessionState(
       session: resumed,
+      resumed: true,
       warmup: const [],
       warmupChecked: const [],
     );

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -195,8 +195,12 @@ class _ActiveWorkoutScreenState extends ConsumerState<ActiveWorkoutScreen> {
     }
 
     final session = sessionState.session;
-    final elapsed = DateTime.now().difference(session.startedAt);
-    final elapsedMin = elapsed.inMinutes;
+    // For a resumed session show the original (saved) duration; otherwise the
+    // live elapsed time. Recomputing now - startedAt for a resumed past session
+    // would show an absurd value (the workout was hours/days ago).
+    final elapsedMin = sessionState.resumed
+        ? ((session.durationSeconds ?? 0) ~/ 60)
+        : DateTime.now().difference(session.startedAt).inMinutes;
 
     final hasWarmup = sessionState.warmup.isNotEmpty;
     final warmupOffset = hasWarmup ? 1 : 0;

--- a/app/lib/features/workout/presentation/workout_home_screen.dart
+++ b/app/lib/features/workout/presentation/workout_home_screen.dart
@@ -35,11 +35,9 @@ class WorkoutHomeScreen extends ConsumerWidget {
               ),
               const SizedBox(height: AppSpacing.xs),
               Text('Oggi', style: Theme.of(context).textTheme.headlineMedium),
-              const SizedBox(height: AppSpacing.md),
-              const _AiActions(),
               const SizedBox(height: AppSpacing.sm),
-              const _NutritionCard(),
-              const SizedBox(height: AppSpacing.lg),
+              const _QuickActions(),
+              const SizedBox(height: AppSpacing.md),
               Expanded(
                 child: planAsync.when(
                   loading: () =>
@@ -85,18 +83,28 @@ class _PlanView extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(plan.name, style: Theme.of(context).textTheme.titleLarge),
-        const SizedBox(height: AppSpacing.xs),
+        Row(
+          children: [
+            Expanded(
+              child: Text(plan.name,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.titleLarge),
+            ),
+            if (plan.description != null && plan.description!.trim().isNotEmpty)
+              IconButton(
+                icon: const Icon(Icons.info_outline, color: AppColors.primary),
+                tooltip: 'Info scheda',
+                onPressed: () =>
+                    _showPlanInfo(context, plan.description!.trim()),
+              ),
+          ],
+        ),
         Text(
           "Scegli l'allenamento di oggi",
           style: Theme.of(context).textTheme.bodyMedium,
         ),
-        const SizedBox(height: AppSpacing.md),
-        if (plan.description != null && plan.description!.trim().isNotEmpty)
-          Padding(
-            padding: const EdgeInsets.only(bottom: AppSpacing.md),
-            child: _PlanInfoCard(text: plan.description!.trim()),
-          ),
+        const SizedBox(height: AppSpacing.sm),
         Expanded(
           child: ListView.separated(
             itemCount: plan.days.length,
@@ -110,7 +118,8 @@ class _PlanView extends ConsumerWidget {
                   padding: const EdgeInsets.all(AppSpacing.md),
                   child: Row(
                     children: [
-                      Icon(Icons.fitness_center, color: AppColors.primary),
+                      const Icon(Icons.fitness_center,
+                          color: AppColors.primary),
                       const SizedBox(width: AppSpacing.md),
                       Expanded(
                         child: Column(
@@ -130,7 +139,7 @@ class _PlanView extends ConsumerWidget {
                           ],
                         ),
                       ),
-                      Icon(Icons.play_circle_fill,
+                      const Icon(Icons.play_circle_fill,
                           size: 36, color: AppColors.primary),
                     ],
                   ),
@@ -189,19 +198,18 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
-/// Two entry points to the AI features (Coach generation + equipment scan).
-class _AiActions extends StatelessWidget {
-  const _AiActions();
+/// Compact quick-actions row: Coach AI, Scansiona, Nutrizione.
+class _QuickActions extends StatelessWidget {
+  const _QuickActions();
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
         Expanded(
-          child: _AiCard(
+          child: _QuickAction(
             icon: Icons.auto_awesome,
             label: 'Coach AI',
-            subtitle: 'Genera scheda',
             onTap: () => Navigator.of(context, rootNavigator: true).push(
               MaterialPageRoute(builder: (_) => const CoachOnboardingScreen()),
             ),
@@ -209,12 +217,22 @@ class _AiActions extends StatelessWidget {
         ),
         const SizedBox(width: AppSpacing.sm),
         Expanded(
-          child: _AiCard(
+          child: _QuickAction(
             icon: Icons.camera_alt,
             label: 'Scansiona',
-            subtitle: 'Riconosci attrezzo',
             onTap: () => Navigator.of(context, rootNavigator: true).push(
               MaterialPageRoute(builder: (_) => const VisionScanScreen()),
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: _QuickAction(
+            icon: Icons.restaurant_menu,
+            label: 'Nutrizione',
+            color: AppColors.success,
+            onTap: () => Navigator.of(context, rootNavigator: true).push(
+              MaterialPageRoute(builder: (_) => const NutritionScreen()),
             ),
           ),
         ),
@@ -223,147 +241,66 @@ class _AiActions extends StatelessWidget {
   }
 }
 
-/// Full-width entry to the Nutrition screen.
-class _NutritionCard extends StatelessWidget {
-  const _NutritionCard();
-
-  @override
-  Widget build(BuildContext context) {
-    return GlassmorphismCard(
-      onTap: () => Navigator.of(context, rootNavigator: true).push(
-        MaterialPageRoute(builder: (_) => const NutritionScreen()),
-      ),
-      padding: const EdgeInsets.all(AppSpacing.md),
-      borderColor: AppColors.success.withValues(alpha: 0.25),
-      child: Row(
-        children: [
-          const Icon(Icons.restaurant_menu, color: AppColors.success, size: 26),
-          const SizedBox(width: AppSpacing.md),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Nutrizione',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleSmall
-                      ?.copyWith(fontWeight: FontWeight.w700),
-                ),
-                Text(
-                  'Calorie e macro su misura + menù',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ],
-            ),
-          ),
-          const Icon(Icons.chevron_right, color: AppColors.textSecondary),
-        ],
-      ),
-    );
-  }
-}
-
-class _AiCard extends StatelessWidget {
-  const _AiCard({
+class _QuickAction extends StatelessWidget {
+  const _QuickAction({
     required this.icon,
     required this.label,
-    required this.subtitle,
     required this.onTap,
+    this.color = AppColors.primary,
   });
 
   final IconData icon;
   final String label;
-  final String subtitle;
   final VoidCallback onTap;
+  final Color color;
 
   @override
   Widget build(BuildContext context) {
     return GlassmorphismCard(
       onTap: onTap,
-      padding: const EdgeInsets.all(AppSpacing.md),
-      borderColor: AppColors.primary.withValues(alpha: 0.25),
-      child: Row(
-        children: [
-          Icon(icon, color: AppColors.primary, size: 26),
-          const SizedBox(width: AppSpacing.sm),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  label,
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleSmall
-                      ?.copyWith(fontWeight: FontWeight.w700),
-                ),
-                Text(
-                  subtitle,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Collapsible card showing the plan description / AI coach explanation
-/// (current situation, objective, progression). Persisted on the plan.
-class _PlanInfoCard extends StatefulWidget {
-  const _PlanInfoCard({required this.text});
-  final String text;
-
-  @override
-  State<_PlanInfoCard> createState() => _PlanInfoCardState();
-}
-
-class _PlanInfoCardState extends State<_PlanInfoCard> {
-  bool _expanded = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return GlassmorphismCard(
-      onTap: () => setState(() => _expanded = !_expanded),
-      padding: const EdgeInsets.all(AppSpacing.md),
-      borderColor: AppColors.primary.withValues(alpha: 0.25),
+      padding: const EdgeInsets.symmetric(
+          vertical: AppSpacing.sm, horizontal: AppSpacing.xs),
+      borderColor: color.withValues(alpha: 0.25),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Row(
-            children: [
-              const Icon(Icons.auto_awesome, color: AppColors.primary, size: 18),
-              const SizedBox(width: AppSpacing.sm),
-              Expanded(
-                child: Text('Info scheda',
-                    style: Theme.of(context)
-                        .textTheme
-                        .titleSmall
-                        ?.copyWith(fontWeight: FontWeight.w700)),
-              ),
-              Icon(_expanded ? Icons.expand_less : Icons.expand_more,
-                  color: AppColors.textSecondary),
-            ],
-          ),
+          Icon(icon, color: color, size: 22),
           const SizedBox(height: 4),
           Text(
-            widget.text,
-            maxLines: _expanded ? null : 2,
-            overflow: _expanded ? null : TextOverflow.ellipsis,
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
             style: Theme.of(context)
                 .textTheme
-                .bodyMedium
-                ?.copyWith(color: AppColors.textSecondary),
+                .labelMedium
+                ?.copyWith(fontWeight: FontWeight.w600),
           ),
         ],
       ),
     );
   }
+}
+
+/// Show the plan description / AI coach explanation in a dialog.
+void _showPlanInfo(BuildContext context, String text) {
+  showDialog<void>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      backgroundColor: AppColors.bgSecondary,
+      title: const Row(
+        children: [
+          Icon(Icons.auto_awesome, color: AppColors.primary, size: 20),
+          SizedBox(width: AppSpacing.sm),
+          Text('Info scheda'),
+        ],
+      ),
+      content: SingleChildScrollView(child: Text(text)),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(ctx),
+          child: const Text('Chiudi'),
+        ),
+      ],
+    ),
+  );
 }

--- a/services/workouts/app/service.py
+++ b/services/workouts/app/service.py
@@ -211,16 +211,36 @@ class WorkoutService:
             pump_rating: Optional pump-sensation rating (1-5).
 
         Returns:
-            Created WorkoutSession object.
+            Created (or updated) WorkoutSession object.
 
         Raises:
-            DuplicateClientIdError: If client_id already exists.
+            DuplicateClientIdError: If the client_id belongs to another user.
         """
-        existing = await self.db.execute(
+        result = await self.db.execute(
             select(WorkoutSession).where(WorkoutSession.client_id == client_id)
         )
-        if existing.scalar_one_or_none():
-            raise DuplicateClientIdError(client_id)
+        existing = result.scalar_one_or_none()
+        if existing is not None:
+            # Same client_id from the same user = a re-uploaded session (e.g. a
+            # finished workout reopened via "resume" and edited). Update it in
+            # place (last-write-wins) instead of rejecting, so the edits persist
+            # server-side. A collision across users is still an error.
+            if existing.user_id != user_id:
+                raise DuplicateClientIdError(client_id)
+            existing.plan_id = plan_id
+            existing.day_name = day_name
+            existing.started_at = started_at
+            existing.completed_at = completed_at
+            existing.duration_seconds = duration_seconds
+            existing.exercises = exercises
+            existing.notes = notes
+            existing.overall_rating = overall_rating
+            existing.fatigue_rating = fatigue_rating
+            existing.pump_rating = pump_rating
+            existing.synced_at = datetime.now(UTC)
+            await self.db.commit()
+            await self.db.refresh(existing)
+            return existing
 
         session = WorkoutSession(
             user_id=user_id,

--- a/services/workouts/migrations/0002_normalize_session_durations.sql
+++ b/services/workouts/migrations/0002_normalize_session_durations.sql
@@ -1,0 +1,14 @@
+-- 0002_normalize_session_durations.sql
+-- Data fix: some workout sessions (imported from the GymTracker prototype and a
+-- former resume bug) have absurd durations — completed_at was stored as
+-- started_at + a corrupted duration, producing 12h-36h "workouts".
+--
+-- Normalize any session longer than 4h (14400s) to a sane 90 min, keeping the
+-- original started_at and recomputing completed_at accordingly.
+-- Idempotent: rows already <= 4h are untouched, so re-running is a no-op.
+
+UPDATE workouts.workout_sessions
+SET
+    duration_seconds = 5400,
+    completed_at = started_at + INTERVAL '90 minutes'
+WHERE duration_seconds > 14400;

--- a/services/workouts/tests/test_sessions.py
+++ b/services/workouts/tests/test_sessions.py
@@ -95,16 +95,30 @@ async def test_create_session_no_auth(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_create_session_duplicate_client_id(client: AsyncClient, auth_headers: dict):
-    """Creating two sessions with the same client_id should return 409."""
+async def test_create_session_same_client_id_upserts(client: AsyncClient, auth_headers: dict):
+    """Re-posting the same client_id should update the session (resume/edit), not duplicate."""
     client_id = str(uuid.uuid4())
     payload = make_session_data(client_id)
 
     first = await client.post("/workouts/sessions", json=payload, headers=auth_headers)
     assert first.status_code == 201
+    first_id = first.json()["id"]
 
+    # Resume + edit: same client_id, changed notes/duration.
+    payload["notes"] = "Added treadmill"
+    payload["duration_seconds"] = 4200
     second = await client.post("/workouts/sessions", json=payload, headers=auth_headers)
-    assert second.status_code == 409
+    assert second.status_code == 201
+    body = second.json()
+    # Same server row, updated fields.
+    assert body["id"] == first_id
+    assert body["notes"] == "Added treadmill"
+    assert body["duration_seconds"] == 4200
+
+    # And the history still contains exactly one session for this client_id.
+    listing = await client.get("/workouts/sessions", headers=auth_headers)
+    matches = [s for s in listing.json()["items"] if s["client_id"] == client_id]
+    assert len(matches) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problema (feedback uso reale)
1. **Durata allenamento ripreso assurda (60h)**: riaprendo un allenamento dallo storico per aggiungere un esercizio e richiudendolo, la durata veniva ricalcolata da `now - startedAt` → 60h.
2. **Info scheda non cliccabile**: il tap sull'icona info in home non faceva nulla.
3. **CRITICO — card dei giorni non visibili**: le card AI/Nutrizione occupavano tutto lo spazio e spingevano in basso le card dei giorni, rendendo l'app inusabile per scegliere l'allenamento.

## Modifiche

### Frontend (`app`)
- **Riprendi allenamento**: aggiunto flag `resumed` allo stato sessione; la durata originale salvata viene mantenuta (header live + completamento) invece di ricalcolarla. Niente più 60h.
- **Home compatta**: azioni AI/Nutrizione ridotte a una riga di 3 pulsanti (Coach AI / Scansiona / Nutrizione) → le card dei giorni tornano subito visibili e selezionabili.
- **Info scheda**: tap sull'icona `info_outline` → dialog con la descrizione della scheda.

### Backend (`workouts`)
- **`create_session` upsert**: stesso `client_id` dello stesso utente → aggiorna la sessione (last-write-wins) invece di restituire 409. Così le modifiche fatte riprendendo un allenamento già sincronizzato vengono **persistite** lato server (prima venivano perse).
- **Migrazione dati `0002`**: normalizza a 90 min le sessioni con durata > 4h (8 sessioni corrotte da import GymTracker / bug precedente). Già applicata in produzione.

## Verifica
- `flutter analyze`: pulito.
- `flutter build web --release`: ok, deployato su webapp.
- Backend `workouts` ricostruito e healthy; migrazione applicata (8 righe normalizzate, max durata ora 2.6h).
- E2E screenshot: home con tutte le 5 card dei giorni visibili e selezionabili; dialog "Info scheda" funzionante.
- Test aggiornato: `test_create_session_same_client_id_upserts` (era `_duplicate_client_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
