### PR TITLE
fix(app): auto-riparazione service worker iOS + cap durata sessione

### DIFF
--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -367,9 +367,13 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
     // correcting/adding to a past workout, not training again from the original
     // start time — recomputing now - startedAt would give absurd values like 60h).
     final elapsed = DateTime.now().difference(s.session.startedAt).inSeconds;
+    // Defensive cap: a real gym session is never longer than ~4h. Anything
+    // beyond means the user left the app open and forgot to finish, so we clamp
+    // it instead of storing an absurd duration.
+    const maxSessionSeconds = 4 * 60 * 60;
     final duration = s.resumed
-        ? (s.session.durationSeconds ?? elapsed)
-        : elapsed;
+        ? (s.session.durationSeconds ?? elapsed.clamp(0, maxSessionSeconds))
+        : elapsed.clamp(0, maxSessionSeconds);
     state = s.copyWith(
       session: s.session.copyWith(
         completedAt: DateTime.now(),

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -35,6 +35,21 @@
   <script src="webauthn.js"></script>
 </head>
 <body>
+  <!--
+    Self-heal for iOS/Safari installed PWAs: when a new service worker takes
+    control after a deploy, reload once so the page never gets stuck on a stale
+    cached shell (the classic white screen after an update).
+  -->
+  <script>
+    if ('serviceWorker' in navigator) {
+      var __reloaded = false;
+      navigator.serviceWorker.addEventListener('controllerchange', function () {
+        if (__reloaded) return;
+        __reloaded = true;
+        window.location.reload();
+      });
+    }
+  </script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## Contesto
Follow-up del feedback uso reale su iPhone:
- la PWA installata mostrava **schermo bianco** dopo un deploy (service worker bloccato sulla shell vecchia);
- comparivano sessioni con **durata assurda** (es. 59h) quando si dimentica di premere FINE.

## Modifiche (solo frontend `app`)

### `web/index.html` — auto-riparazione service worker (iOS)
Aggiunta una guardia che, al primo `controllerchange` (quando un nuovo service worker prende il controllo dopo un deploy), ricarica la pagina **una volta**. Elimina lo schermo bianco delle PWA iOS installate, che altrimenti restano sulla shell in cache finché iOS non aggiorna pigramente il SW.

### `active_session_notifier.dart` — cap difensivo sulla durata
Al completamento, la durata calcolata (`now - startedAt`) viene limitata a **4h** max. Una sessione di palestra non dura mai di più: oltre quel valore significa che l'app è rimasta aperta. Così non si salvano più durate assurde a prescindere dalla causa. Per le sessioni *riprese* resta valida la durata originale (fix precedente).

## Verifica
- `flutter analyze`: pulito.
- `flutter build web --release` + deploy webapp: ok.
- Live: `index.html` contiene la guardia `controllerchange`; nuovo `serviceWorkerVersion` (3527778318).
- E2E: la home si carica correttamente con tutte le card dei giorni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
