### PR TITLE
feat(app): riordino esercizi + testo superset leggibile

### DIFF
--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -350,6 +350,26 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
     _save();
   }
 
+  /// Reorder exercises: move the one at [oldIndex] to [newIndex].
+  /// Used by the up/down controls so the user can change the order during a
+  /// workout (and reposition an exercise added at the end).
+  void moveExercise(int oldIndex, int newIndex) {
+    final s = state;
+    if (s == null) return;
+    final exercises = List<ExerciseLog>.from(s.session.exercises);
+    if (oldIndex < 0 || oldIndex >= exercises.length) return;
+    if (newIndex < 0 || newIndex >= exercises.length) return;
+    if (oldIndex == newIndex) return;
+
+    final moved = exercises.removeAt(oldIndex);
+    exercises.insert(newIndex, moved);
+
+    state = s.copyWith(
+      session: s.session.copyWith(exercises: exercises),
+    );
+    _save();
+  }
+
   /// Move to a specific exercise index.
   void goToExercise(int index) {
     final s = state;

--- a/app/lib/features/workout/presentation/active_workout_screen.dart
+++ b/app/lib/features/workout/presentation/active_workout_screen.dart
@@ -456,6 +456,8 @@ class _ExerciseBody extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final total = ref.watch(
+        activeSessionProvider.select((s) => s?.totalExercises ?? 0));
     return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -491,8 +493,24 @@ class _ExerciseBody extends ConsumerWidget {
                     ],
                   ),
                 ),
+                // Reorder up/down — lets the user change exercise order mid-workout.
+                _ReorderArrow(
+                  icon: Icons.keyboard_arrow_up,
+                  enabled: exerciseIndex > 0,
+                  onPressed: () => ref
+                      .read(activeSessionProvider.notifier)
+                      .moveExercise(exerciseIndex, exerciseIndex - 1),
+                ),
+                _ReorderArrow(
+                  icon: Icons.keyboard_arrow_down,
+                  enabled: exerciseIndex < total - 1,
+                  onPressed: () => ref
+                      .read(activeSessionProvider.notifier)
+                      .moveExercise(exerciseIndex, exerciseIndex + 1),
+                ),
                 // Skip / Unskip
                 IconButton(
+                  visualDensity: VisualDensity.compact,
                   icon: Icon(
                     exercise.skipped ? Icons.undo : Icons.skip_next,
                     color: AppColors.textSecondary,
@@ -640,30 +658,32 @@ class _SupersetCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Icon(Icons.bolt, color: AppColors.warning, size: 18),
-                const SizedBox(width: AppSpacing.xs),
-                const Text(
-                  'SUPERSET',
-                  style: TextStyle(
-                    color: AppColors.warning,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 1.5,
-                  ),
+                const Row(
+                  children: [
+                    Icon(Icons.bolt, color: AppColors.warning, size: 18),
+                    SizedBox(width: AppSpacing.xs),
+                    Text(
+                      'SUPERSET',
+                      style: TextStyle(
+                        color: AppColors.warning,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 1.5,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: Text(
-                    'esegui di fila, recupero alla fine del giro',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodySmall
-                        ?.copyWith(color: AppColors.textSecondary),
-                  ),
+                const SizedBox(height: 2),
+                // Full description on its own line so it's never truncated.
+                Text(
+                  'Esegui gli esercizi di fila, recupero alla fine del giro',
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: AppColors.textSecondary),
                 ),
               ],
             ),
@@ -695,6 +715,34 @@ const _headerStyle = TextStyle(
   fontWeight: FontWeight.w600,
   letterSpacing: 0.5,
 );
+
+/// Compact up/down control to reorder an exercise during a workout.
+class _ReorderArrow extends StatelessWidget {
+  const _ReorderArrow({
+    required this.icon,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final bool enabled;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      visualDensity: VisualDensity.compact,
+      padding: EdgeInsets.zero,
+      constraints: const BoxConstraints(minWidth: 30, minHeight: 32),
+      iconSize: 24,
+      tooltip: icon == Icons.keyboard_arrow_up ? 'Sposta su' : 'Sposta giù',
+      icon: Icon(icon),
+      color: AppColors.textSecondary,
+      disabledColor: AppColors.textDisabled.withValues(alpha: 0.3),
+      onPressed: enabled ? onPressed : null,
+    );
+  }
+}
 
 /// Summary row in the completion dialog.
 class _SummaryRow extends StatelessWidget {


### PR DESCRIPTION
## Feedback uso reale (schermata allenamento attivo)
1. **Non si poteva cambiare l'ordine degli esercizi**, e un esercizio aggiunto finiva solo in fondo.
2. La **descrizione del SUPERSET era troncata** ("esegui di fila, recupero a…").

## Modifiche (solo frontend `app`)

### Riordino esercizi
- Frecce **su/giù** (`▲ ▼`) in ogni intestazione esercizio per cambiare l'ordine durante l'allenamento; disabilitate ai bordi (la prima non va su, l'ultima non va giù).
- Risolve anche il punto 1.b: un esercizio aggiunto in fondo si può ora spostare verso l'alto.
- Nuovo metodo `moveExercise(oldIndex, newIndex)` nel notifier (rimuove + reinserisce, ricalcola il raggruppamento superset).

### Testo SUPERSET leggibile
- La descrizione passa su una **riga propria** sotto il badge SUPERSET: "Esegui gli esercizi di fila, recupero alla fine del giro" — niente più troncamento.

## Verifica
- `flutter analyze`: pulito.
- `flutter build web --release` + deploy webapp: ok.
- E2E (avvio "Lower B"): frecce di riordino presenti e disabilitate correttamente ai bordi; descrizione SUPERSET completa su riga propria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
