### PR TITLE
fix(app): salva/sincronizza allenamenti + ripristina sessione in corso

### DIFF
--- a/app/lib/core/network/token_storage.dart
+++ b/app/lib/core/network/token_storage.dart
@@ -1,14 +1,16 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+import 'package:fitness_ai/core/storage/hive_storage.dart';
+
 /// Secure storage for JWT tokens.
 ///
 /// Uses flutter_secure_storage (Keychain on iOS, EncryptedSharedPreferences
-/// on Android). On web, secure-storage reads are unreliable, so we keep an
-/// in-memory copy of the tokens for the current session and treat persistent
-/// storage as best-effort (wrapped in try/catch). This guarantees the access
-/// token is available to the auth interceptor immediately after login on every
-/// platform, while still surviving app restarts where storage works.
+/// on Android). On WEB, secure-storage is unreliable and effectively in-memory,
+/// so tokens were lost whenever the PWA was reloaded/evicted (iOS killing the
+/// tab during cardio), logging the user out. To fix that we also persist tokens
+/// in the Hive `user` box (IndexedDB on web, file on mobile) as a durable,
+/// cross-platform store, with an in-memory cache for speed.
 class TokenStorage {
   TokenStorage({FlutterSecureStorage? storage})
       : _storage = storage ?? const FlutterSecureStorage();
@@ -22,9 +24,23 @@ class TokenStorage {
   static String? _accessMem;
   static String? _refreshMem;
 
-  /// Read the stored access token (memory first, then persistent storage).
+  String? _fromHive(String key) {
+    try {
+      final v = HiveStorage.user.get(key);
+      return (v is String && v.isNotEmpty) ? v : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Read the stored access token (memory → durable Hive → secure storage).
   Future<String?> getAccessToken() async {
     if (_accessMem != null) return _accessMem;
+    final hiveVal = _fromHive(_accessTokenKey);
+    if (hiveVal != null) {
+      _accessMem = hiveVal;
+      return _accessMem;
+    }
     try {
       _accessMem = await _storage.read(key: _accessTokenKey);
     } catch (_) {
@@ -33,9 +49,14 @@ class TokenStorage {
     return _accessMem;
   }
 
-  /// Read the stored refresh token (memory first, then persistent storage).
+  /// Read the stored refresh token (memory → durable Hive → secure storage).
   Future<String?> getRefreshToken() async {
     if (_refreshMem != null) return _refreshMem;
+    final hiveVal = _fromHive(_refreshTokenKey);
+    if (hiveVal != null) {
+      _refreshMem = hiveVal;
+      return _refreshMem;
+    }
     try {
       _refreshMem = await _storage.read(key: _refreshTokenKey);
     } catch (_) {
@@ -52,6 +73,12 @@ class TokenStorage {
     // Memory first so it is immediately usable this session.
     _accessMem = accessToken;
     _refreshMem = refreshToken;
+    // Durable cross-platform store (survives PWA reload/eviction on web).
+    try {
+      await HiveStorage.user.put(_accessTokenKey, accessToken);
+      await HiveStorage.user.put(_refreshTokenKey, refreshToken);
+    } catch (_) {}
+    // Secure storage as a secondary on mobile (best-effort).
     try {
       await Future.wait([
         _storage.write(key: _accessTokenKey, value: accessToken),
@@ -66,6 +93,10 @@ class TokenStorage {
   Future<void> clearTokens() async {
     _accessMem = null;
     _refreshMem = null;
+    try {
+      await HiveStorage.user.delete(_accessTokenKey);
+      await HiveStorage.user.delete(_refreshTokenKey);
+    } catch (_) {}
     try {
       await Future.wait([
         _storage.delete(key: _accessTokenKey),

--- a/app/lib/features/history/data/history_repository.dart
+++ b/app/lib/features/history/data/history_repository.dart
@@ -18,16 +18,26 @@ class HistoryRepository {
   /// Parsing is per-record defensive: a single malformed cached entry can
   /// never blank the whole screen.
   List<WorkoutSession> getLocalSessions() {
-    final out = <WorkoutSession>[];
+    // Dedup by (clientId ?? id): a workout can exist both as the local copy
+    // (id = local uuid) and as the copy fetched back from the server (id =
+    // server uuid, clientId = local uuid). Prefer the server copy.
+    final byKey = <String, WorkoutSession>{};
     for (final m in HiveStorage.sessions.values) {
       try {
         final s = WorkoutSession.fromJson(Map<String, dynamic>.from(m));
-        if (s.isCompleted) out.add(s);
+        if (!s.isCompleted) continue;
+        final key = s.clientId ?? s.id;
+        final existing = byKey[key];
+        // Keep the server copy (the one carrying a clientId) when both exist.
+        if (existing == null || (existing.clientId == null && s.clientId != null)) {
+          byKey[key] = s;
+        }
       } catch (_) {
         // skip corrupt/incompatible cached record
       }
     }
-    out.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    final out = byKey.values.toList()
+      ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
     return out;
   }
 
@@ -69,10 +79,16 @@ class HistoryRepository {
               WorkoutSession.fromJson(item as Map<String, dynamic>))
           .toList();
 
-      // Cache locally
+      // Cache locally. Each server session carries the original client_id; if a
+      // pre-sync local copy is still stored under that id, remove it so the
+      // workout isn't shown twice.
       for (final session in sessions) {
         final cached = session.copyWith(synced: true);
         await HiveStorage.sessions.put(cached.id, cached.toJson());
+        final cid = session.clientId;
+        if (cid != null && cid != cached.id) {
+          await HiveStorage.sessions.delete(cid);
+        }
       }
 
       return sessions;

--- a/app/lib/features/history/presentation/history_screen.dart
+++ b/app/lib/features/history/presentation/history_screen.dart
@@ -27,12 +27,24 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     _loadSessions();
   }
 
-  void _loadSessions() {
+  Future<void> _loadSessions() async {
     final repo = ref.read(historyRepositoryProvider);
+    // Show the local cache immediately...
     setState(() {
       _sessions = repo.getLocalSessions();
       _loading = false;
     });
+    // ...then refresh from the server and merge, so history is recovered even
+    // if the local cache was wiped (e.g. after reinstalling the PWA). Offline
+    // failures are ignored — the local list stays visible.
+    try {
+      await repo.fetchSessions();
+      if (mounted) {
+        setState(() => _sessions = repo.getLocalSessions());
+      }
+    } catch (_) {
+      // offline or server error: keep showing the local cache
+    }
   }
 
   Future<bool> _confirmDelete(WorkoutSession session) async {
@@ -78,10 +90,10 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(
+          const Padding(
+            padding: EdgeInsets.fromLTRB(
                 AppSpacing.lg, AppSpacing.lg, AppSpacing.lg, AppSpacing.sm),
-            child: const GradientText(
+            child: GradientText(
               'Storico',
               style: TextStyle(fontSize: 28, fontWeight: FontWeight.w900),
             ),

--- a/app/lib/features/workout/domain/workout_session.dart
+++ b/app/lib/features/workout/domain/workout_session.dart
@@ -15,9 +15,16 @@ class WorkoutSession {
     this.overallRating = 0,
     this.fatigueRating = 0,
     this.pumpRating = 0,
+    this.clientId,
   });
 
   final String id;
+
+  /// The original local id used as the server dedup key. On a session fetched
+  /// back from the server this holds the local id it was created with, so the
+  /// server copy and the local copy can be recognised as the same workout.
+  final String? clientId;
+
   final String? planId;
   final String? dayName;
   final DateTime startedAt;
@@ -79,6 +86,7 @@ class WorkoutSession {
     int? overallRating,
     int? fatigueRating,
     int? pumpRating,
+    String? clientId,
   }) {
     return WorkoutSession(
       id: id ?? this.id,
@@ -93,12 +101,14 @@ class WorkoutSession {
       overallRating: overallRating ?? this.overallRating,
       fatigueRating: fatigueRating ?? this.fatigueRating,
       pumpRating: pumpRating ?? this.pumpRating,
+      clientId: clientId ?? this.clientId,
     );
   }
 
   factory WorkoutSession.fromJson(Map<String, dynamic> json) {
     return WorkoutSession(
       id: json['id'].toString(),
+      clientId: json['client_id']?.toString(),
       planId: json['plan_id']?.toString(),
       dayName: json['day_name'] as String?,
       startedAt: json['started_at'] is DateTime
@@ -125,6 +135,7 @@ class WorkoutSession {
 
   Map<String, dynamic> toJson() => {
         'id': id,
+        'client_id': clientId,
         'plan_id': planId,
         'day_name': dayName,
         'started_at': startedAt.toIso8601String(),

--- a/app/lib/features/workout/presentation/active_session_notifier.dart
+++ b/app/lib/features/workout/presentation/active_session_notifier.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:fitness_ai/core/sync/sync_service.dart';
 import 'package:fitness_ai/features/workout/data/workout_repository.dart';
 import 'package:fitness_ai/features/workout/domain/exercise_log.dart';
 import 'package:fitness_ai/features/workout/domain/set_log.dart';
@@ -70,9 +73,28 @@ class ActiveSessionState {
 /// Manages the active workout session state.
 class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
   @override
-  ActiveSessionState? build() => null;
+  ActiveSessionState? build() => _restoreInProgress();
 
   WorkoutRepository get _repo => ref.read(workoutRepositoryProvider);
+
+  /// Restore an unfinished session from local storage so an in-progress
+  /// workout survives the app being reloaded/evicted (e.g. iOS killing the PWA
+  /// after the user leaves it idle during cardio). Only a recent (< 24h) session
+  /// is restored; older orphans are ignored.
+  ActiveSessionState? _restoreInProgress() {
+    try {
+      final inProgress = _repo
+          .getAllLocalSessions() // newest-first
+          .where((s) => !s.isCompleted)
+          .toList();
+      if (inProgress.isEmpty) return null;
+      final s = inProgress.first;
+      if (DateTime.now().difference(s.startedAt).inHours > 24) return null;
+      return ActiveSessionState(session: s);
+    } catch (_) {
+      return null;
+    }
+  }
 
   /// Start a new session from a workout day plan.
   /// Pre-fills weights from the last completed session for the same day.
@@ -402,6 +424,10 @@ class ActiveSessionNotifier extends Notifier<ActiveSessionState?> {
       isCompleted: true,
     );
     _save();
+    // Push the finished workout to the server right away so it's never lost if
+    // the local cache is later cleared. Fire-and-forget; the periodic sync is a
+    // backup. Reading the provider also keeps the background sync alive.
+    unawaited(ref.read(syncServiceProvider).syncAll());
   }
 
   /// Toggle a warmup item checkbox.

--- a/app/lib/features/workout/presentation/workout_home_screen.dart
+++ b/app/lib/features/workout/presentation/workout_home_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:fitness_ai/core/sync/sync_service.dart';
 import 'package:fitness_ai/core/theme/app_colors.dart';
 import 'package:fitness_ai/core/theme/app_spacing.dart';
 import 'package:fitness_ai/core/widgets/widgets.dart';
 import 'package:fitness_ai/features/workout/domain/workout_plan.dart';
+import 'package:fitness_ai/features/workout/domain/workout_session.dart';
 import 'package:fitness_ai/features/workout/presentation/active_plan_provider.dart';
 import 'package:fitness_ai/features/workout/presentation/active_session_notifier.dart';
 import 'package:fitness_ai/features/workout/presentation/active_workout_screen.dart';
@@ -21,6 +23,13 @@ class WorkoutHomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final planAsync = ref.watch(activePlanProvider);
+    // Keep the background sync service alive while the app is open so finished
+    // workouts get pushed to the server (periodic + on reconnect).
+    ref.watch(syncServiceProvider);
+    // An unfinished session restored from storage (e.g. after the app was
+    // evicted mid-workout) — offer to jump back into it.
+    final active = ref.watch(activeSessionProvider);
+    final hasActive = active != null && !active.isCompleted;
     return Scaffold(
       body: SafeArea(
         child: Padding(
@@ -36,6 +45,10 @@ class WorkoutHomeScreen extends ConsumerWidget {
               const SizedBox(height: AppSpacing.xs),
               Text('Oggi', style: Theme.of(context).textTheme.headlineMedium),
               const SizedBox(height: AppSpacing.sm),
+              if (hasActive) ...[
+                _ResumeBanner(session: active.session),
+                const SizedBox(height: AppSpacing.sm),
+              ],
               const _QuickActions(),
               const SizedBox(height: AppSpacing.md),
               Expanded(
@@ -193,6 +206,50 @@ class _EmptyState extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Banner shown on the home when there is an unfinished workout to resume,
+/// so an in-progress session is never lost after an app reload.
+class _ResumeBanner extends StatelessWidget {
+  const _ResumeBanner({required this.session});
+
+  final WorkoutSession session;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassmorphismCard(
+      onTap: () => Navigator.of(context, rootNavigator: true).push(
+        MaterialPageRoute(builder: (_) => const ActiveWorkoutScreen()),
+      ),
+      borderColor: AppColors.warning.withValues(alpha: 0.5),
+      child: Row(
+        children: [
+          const Icon(Icons.play_circle_fill,
+              color: AppColors.warning, size: 32),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Allenamento in corso',
+                    style: Theme.of(context).textTheme.titleMedium),
+                Text(
+                  'Riprendi ${session.dayName ?? 'la sessione'}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: AppColors.textSecondary),
+                ),
+              ],
+            ),
+          ),
+          const Icon(Icons.chevron_right, color: AppColors.warning),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Bug riportati (uso reale)
1. **Allenamenti della settimana spariti dallo Storico** — completati ma non presenti.
2. **La sessione attiva spariva** dopo ~30 min di inattività (cardio/chiacchiere): non era nemmeno nello Storico, impossibile recuperarla → ricominciare da capo, tempi sballati.

## Indagine — tre cause distinte
- **Token non persistiti su web**: `TokenStorage` usava solo `flutter_secure_storage`, inaffidabile su web (di fatto in memoria). iOS chiude la PWA inattiva → al riavvio **utente sloggato**.
- **Sessione in corso mai ripristinata**: `ActiveSessionNotifier.build()` ritornava sempre `null`. Dopo un riavvio l'allenamento in corso spariva (resta in Hive ma non è né attivo né nello Storico perché non completato).
- **Sync mai attivo + Storico solo locale**: `SyncIndicator` (unico a istanziare `syncServiceProvider`) non era montato da nessuna parte → il sync automatico **non partiva mai**, gli allenamenti completati non arrivavano al server (confermato: server fermo al 2 giugno). E lo Storico leggeva **solo** la cache locale → pulendo la PWA (per il bug schermo bianco) la cronologia è andata persa.

## Modifiche (frontend `app`)
- **`token_storage.dart`**: token salvati anche in Hive (IndexedDB) → durevoli su web/mobile, niente più logout dopo eviction.
- **`active_session_notifier.dart`**: `build()` ripristina la sessione non completata più recente (< 24h); `completeSession()` lancia subito il sync.
- **`workout_home_screen.dart`**: banner "Allenamento in corso – Riprendi" quando c'è una sessione aperta; tiene vivo `syncServiceProvider`.
- **`history_repository.dart` / `history_screen.dart`**: lo Storico fa fetch dal server e fonde con il locale (recupero dopo wipe); dedup via `client_id`.
- **`workout_session.dart`**: aggiunto `client_id` per il dedup copia locale vs copia server.

## Verifica (E2E, viewport 390×844)
- Dopo un **reload** (simula l'eviction iOS): l'app **resta loggata** e la home mostra il banner "Allenamento in corso – Riprendi Lower A".
- **Storico**: in un browser pulito (cache locale vuota) recupera tutte le sessioni **dal server**.
- `flutter analyze` pulito; build web ok; deploy verificato.
- Nessun allenamento completato creato in verifica, per non sporcare lo storico reale.

> Nota: gli allenamenti di questa settimana erano solo in locale e mai sincronizzati; la cache è stata svuotata → non sono recuperabili. Da ora vengono salvati sul server al completamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
